### PR TITLE
feat: assistente de divulgação para igrejas

### DIFF
--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -41,7 +41,7 @@ const navItems = [
   { path: "/igreja", label: "Igrejas", icon: ChurchIcon },
   { path: "/solicitacoes", label: "Solicitações", icon: BuildIcon },
   { path: "/contribuidores", label: "Contribuidores", icon: CurrencyExchangeIcon },
-  { path: "/email-evento", label: "E-mails Evento", icon: EmailIcon },
+  { path: "/email-evento", label: "Divulgação", icon: EmailIcon },
   { path: "/indicadores", label: "Indicadores", icon: InsightsIcon },
 ];
 
@@ -53,7 +53,7 @@ const pageTitles = {
   "/contribuidores": "Contribuidores",
   "/igrejaNovo": "Nova Igreja",
   "/igrejaEditar": "Editar Igreja",
-  "/email-evento": "E-mails Evento",
+  "/email-evento": "Divulgação das Igrejas",
   "/indicadores": "Indicadores",
 };
 

--- a/src/EmailEvento/EmailEvento.jsx
+++ b/src/EmailEvento/EmailEvento.jsx
@@ -28,25 +28,51 @@ import {
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import AddIcon from "@mui/icons-material/Add";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Menu from "../Components/Menu";
 import Pagination from "../Components/Paginacao";
 import api from "../services/apiService";
 import ErrorSpan from "../ErrorSpan";
+import {
+  gerarMensagemInstagram,
+  gerarMensagemFacebook,
+  construirLinkIgreja,
+} from "../services/mensagemDivulgacao";
 
 const TIPOS_EMAIL = [
   { value: "", label: "Todos" },
   { value: "criacao", label: "Criação" },
   { value: "alteracao", label: "Alteração" },
+  { value: "notificacao", label: "Notificação" },
+  { value: "validacao", label: "Validação" },
+  { value: "outro", label: "Outro" },
 ];
+
+const TIPO_LABEL = {
+  1: "Criação",
+  2: "Alteração",
+  3: "Notificação",
+  4: "Validação",
+  99: "Outro",
+};
+
+const CANAL_LABEL = {
+  1: "E-mail",
+  2: "Instagram",
+  3: "Facebook",
+};
 
 const filtrosIniciais = {
   IgrejaId: "",
+  IgrejaNome: "",
+  Cidade: "",
   Tipo: "",
+  Canal: "",
   EmailDestino: "",
-  Ativo: "",
   Enviado: "",
-  DataCriacaoInicio: "",
-  DataCriacaoFim: "",
+  DataEnvioInicio: "",
+  DataEnvioFim: "",
 };
 
 const formInicialCriar = {
@@ -98,12 +124,14 @@ const EmailEventoPage = () => {
         params.append("PageSize", paginacao.pageSize);
 
         if (filtrosAplicados.IgrejaId) params.append("IgrejaId", filtrosAplicados.IgrejaId);
+        if (filtrosAplicados.IgrejaNome) params.append("IgrejaNome", filtrosAplicados.IgrejaNome);
+        if (filtrosAplicados.Cidade) params.append("Cidade", filtrosAplicados.Cidade);
         if (filtrosAplicados.Tipo) params.append("Tipo", filtrosAplicados.Tipo);
+        if (filtrosAplicados.Canal) params.append("Canal", filtrosAplicados.Canal);
         if (filtrosAplicados.EmailDestino) params.append("EmailDestino", filtrosAplicados.EmailDestino);
-        if (filtrosAplicados.Ativo !== "") params.append("Ativo", filtrosAplicados.Ativo);
         if (filtrosAplicados.Enviado !== "") params.append("Enviado", filtrosAplicados.Enviado);
-        if (filtrosAplicados.DataCriacaoInicio) params.append("DataCriacaoInicio", filtrosAplicados.DataCriacaoInicio);
-        if (filtrosAplicados.DataCriacaoFim) params.append("DataCriacaoFim", filtrosAplicados.DataCriacaoFim);
+        if (filtrosAplicados.DataEnvioInicio) params.append("DataEnvioInicio", filtrosAplicados.DataEnvioInicio);
+        if (filtrosAplicados.DataEnvioFim) params.append("DataEnvioFim", filtrosAplicados.DataEnvioFim);
 
         const response = await api.get(`/api/v1/Admin/email-evento/buscar-por-filtro?${params.toString()}`);
         const data = response.data?.data || response.data;
@@ -227,12 +255,18 @@ const EmailEventoPage = () => {
           </Typography>
           <Box display="flex" flexWrap="wrap" gap={2}>
             <TextField
-              label="Igreja ID"
-              value={filtros.IgrejaId}
-              onChange={(e) => setFiltros((p) => ({ ...p, IgrejaId: e.target.value }))}
+              label="Igreja"
+              value={filtros.IgrejaNome}
+              onChange={(e) => setFiltros((p) => ({ ...p, IgrejaNome: e.target.value }))}
               size="small"
-              type="number"
-              sx={{ minWidth: 120 }}
+              sx={{ minWidth: 180 }}
+            />
+            <TextField
+              label="Cidade"
+              value={filtros.Cidade}
+              onChange={(e) => setFiltros((p) => ({ ...p, Cidade: e.target.value }))}
+              size="small"
+              sx={{ minWidth: 160 }}
             />
             <FormControl size="small" sx={{ minWidth: 150 }}>
               <InputLabel>Tipo</InputLabel>
@@ -248,23 +282,17 @@ const EmailEventoPage = () => {
                 ))}
               </Select>
             </FormControl>
-            <TextField
-              label="E-mail Destino"
-              value={filtros.EmailDestino}
-              onChange={(e) => setFiltros((p) => ({ ...p, EmailDestino: e.target.value }))}
-              size="small"
-              sx={{ minWidth: 200 }}
-            />
-            <FormControl size="small" sx={{ minWidth: 130 }}>
-              <InputLabel>Ativo</InputLabel>
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <InputLabel>Canal</InputLabel>
               <Select
-                label="Ativo"
-                value={filtros.Ativo}
-                onChange={(e) => setFiltros((p) => ({ ...p, Ativo: e.target.value }))}
+                label="Canal"
+                value={filtros.Canal}
+                onChange={(e) => setFiltros((p) => ({ ...p, Canal: e.target.value }))}
               >
                 <MenuItem value="">Todos</MenuItem>
-                <MenuItem value="true">Sim</MenuItem>
-                <MenuItem value="false">Não</MenuItem>
+                <MenuItem value="1">E-mail</MenuItem>
+                <MenuItem value="2">Instagram</MenuItem>
+                <MenuItem value="3">Facebook</MenuItem>
               </Select>
             </FormControl>
             <FormControl size="small" sx={{ minWidth: 130 }}>
@@ -280,22 +308,22 @@ const EmailEventoPage = () => {
               </Select>
             </FormControl>
             <TextField
-              label="Data Criação Início"
-              type="datetime-local"
-              value={filtros.DataCriacaoInicio}
-              onChange={(e) => setFiltros((p) => ({ ...p, DataCriacaoInicio: e.target.value }))}
+              label="Data Envio Início"
+              type="date"
+              value={filtros.DataEnvioInicio}
+              onChange={(e) => setFiltros((p) => ({ ...p, DataEnvioInicio: e.target.value }))}
               size="small"
               InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 210 }}
+              sx={{ minWidth: 180 }}
             />
             <TextField
-              label="Data Criação Fim"
-              type="datetime-local"
-              value={filtros.DataCriacaoFim}
-              onChange={(e) => setFiltros((p) => ({ ...p, DataCriacaoFim: e.target.value }))}
+              label="Data Envio Fim"
+              type="date"
+              value={filtros.DataEnvioFim}
+              onChange={(e) => setFiltros((p) => ({ ...p, DataEnvioFim: e.target.value }))}
               size="small"
               InputLabelProps={{ shrink: true }}
-              sx={{ minWidth: 210 }}
+              sx={{ minWidth: 180 }}
             />
           </Box>
           <Box display="flex" gap={1} mt={2}>
@@ -311,7 +339,7 @@ const EmailEventoPage = () => {
         {/* Tabela */}
         <TableContainer component={Paper} sx={{ p: 2, borderRadius: 2 }}>
           <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-            <Typography variant="h6">E-mails Evento</Typography>
+            <Typography variant="h6">Divulgação das Igrejas</Typography>
             <Button variant="contained" startIcon={<AddIcon />} onClick={abrirModalCriar}>
               Novo
             </Button>
@@ -326,13 +354,12 @@ const EmailEventoPage = () => {
               <Table size="small">
                 <TableHead>
                   <TableRow>
-                    <TableCell>ID</TableCell>
-                    <TableCell>Igreja ID</TableCell>
+                    <TableCell>Igreja</TableCell>
                     <TableCell>Tipo</TableCell>
-                    <TableCell>E-mail Destino</TableCell>
-                    <TableCell>Ativo</TableCell>
-                    <TableCell>Enviado</TableCell>
-                    <TableCell>Data Criação</TableCell>
+                    <TableCell>Canal</TableCell>
+                    <TableCell>Destino</TableCell>
+                    <TableCell>Data do Envio</TableCell>
+                    <TableCell>Status</TableCell>
                     <TableCell>Ações</TableCell>
                   </TableRow>
                 </TableHead>
@@ -340,37 +367,81 @@ const EmailEventoPage = () => {
                   {registros.length > 0 ? (
                     registros.map((r) => (
                       <TableRow key={r.id}>
-                        <TableCell>{r.id}</TableCell>
-                        <TableCell>{r.igrejaId}</TableCell>
-                        <TableCell>{r.tipo}</TableCell>
-                        <TableCell>{r.emailDestino}</TableCell>
+                        <TableCell>{r.igrejaNome || `#${r.igrejaId}`}</TableCell>
+                        <TableCell>{TIPO_LABEL[r.tipo] ?? r.tipo}</TableCell>
+                        <TableCell>{CANAL_LABEL[r.canal] ?? r.canal}</TableCell>
+                        <TableCell sx={{ maxWidth: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {r.destinoContato || r.emailDestino || "-"}
+                        </TableCell>
+                        <TableCell>{r.dataEnvio ? formatarData(r.dataEnvio) : "-"}</TableCell>
                         <TableCell>
                           <Chip
-                            label={r.ativo ? "Sim" : "Não"}
-                            color={r.ativo ? "success" : "default"}
+                            label={r.enviado ? "Enviado" : "Pendente"}
+                            color={r.enviado ? "success" : "default"}
                             size="small"
                           />
                         </TableCell>
                         <TableCell>
-                          <Chip
-                            label={r.enviado ? "Sim" : "Não"}
-                            color={r.enviado ? "info" : "default"}
-                            size="small"
-                          />
-                        </TableCell>
-                        <TableCell>{formatarData(r.dataCriacao)}</TableCell>
-                        <TableCell>
+                          <Box display="flex" alignItems="center" gap={0.5} flexWrap="wrap">
+                          {r.canal === 2 && r.destinoContato && (
+                            <Tooltip title="Abrir Instagram">
+                              <IconButton
+                                size="small"
+                                onClick={() => {
+                                  const url = r.destinoContato.startsWith("http") ? r.destinoContato : `https://${r.destinoContato}`;
+                                  window.open(url, "_blank", "noopener,noreferrer");
+                                }}
+                              >
+                                <OpenInNewIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                          {r.canal === 3 && r.destinoContato && (
+                            <Tooltip title="Abrir Facebook">
+                              <IconButton
+                                size="small"
+                                onClick={() => {
+                                  const url = r.destinoContato.startsWith("http") ? r.destinoContato : `https://${r.destinoContato}`;
+                                  window.open(url, "_blank", "noopener,noreferrer");
+                                }}
+                              >
+                                <OpenInNewIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                          {(r.canal === 2 || r.canal === 3) && (
+                            <Tooltip title="Copiar mensagem">
+                              <IconButton
+                                size="small"
+                                onClick={() => {
+                                  const igreja = {
+                                    nome: r.igrejaNome,
+                                    endereco: { uf: r.igrejaUf, cidadeSlug: r.igrejaCidadeSlug },
+                                    slug: r.igrejaSlug,
+                                  };
+                                  const link = construirLinkIgreja(igreja);
+                                  const msg = r.canal === 2
+                                    ? gerarMensagemInstagram(r.igrejaNome, link)
+                                    : gerarMensagemFacebook(r.igrejaNome, link);
+                                  navigator.clipboard.writeText(msg).catch(() => {});
+                                }}
+                              >
+                                <ContentCopyIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          )}
                           <Tooltip title="Editar">
                             <IconButton size="small" onClick={() => abrirModalEditar(r)}>
                               <EditIcon fontSize="small" />
                             </IconButton>
                           </Tooltip>
+                          </Box>
                         </TableCell>
                       </TableRow>
                     ))
                   ) : (
                     <TableRow>
-                      <TableCell colSpan={8} align="center">
+                      <TableCell colSpan={7} align="center">
                         Nenhum registro encontrado.
                       </TableCell>
                     </TableRow>
@@ -378,7 +449,7 @@ const EmailEventoPage = () => {
                 </TableBody>
                 <TableFooter>
                   <TableRow>
-                    <TableCell colSpan={8} align="right">
+                    <TableCell colSpan={7} align="right">
                       Total: {paginacao.totalItems ?? registros.length}
                     </TableCell>
                   </TableRow>

--- a/src/Igreja/Components/AssistenteDivulgacao.jsx
+++ b/src/Igreja/Components/AssistenteDivulgacao.jsx
@@ -1,0 +1,220 @@
+/* eslint-disable react/prop-types */
+import { useState } from "react";
+import {
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import LinkIcon from "@mui/icons-material/Link";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import api from "../../services/apiService";
+import {
+  gerarMensagemInstagram,
+  gerarMensagemFacebook,
+  construirLinkIgreja,
+} from "../../services/mensagemDivulgacao";
+
+// TipoEmailEventoIgrejaEnum: Outro = 99
+// CanalContatoEnum: Email=1, Instagram=2, Facebook=3
+const copiar = (texto) => navigator.clipboard.writeText(texto).catch(() => {});
+
+const SecaoEmail = ({ email, emailCriacaoEnviado, opcao, onChange }) => (
+  <Stack spacing={1}>
+    <Typography variant="subtitle2" fontWeight={600}>
+      E-mail
+    </Typography>
+    <Typography variant="body2" color="text.secondary">
+      {email}
+    </Typography>
+    <RadioGroup value={opcao} onChange={(e) => onChange(e.target.value)}>
+      <FormControlLabel value="" control={<Radio size="small" />} label="Não enviar" />
+      {!emailCriacaoEnviado && (
+        <FormControlLabel value="criacao" control={<Radio size="small" />} label="Enviar e-mail de criação" />
+      )}
+      <FormControlLabel value="alteracao" control={<Radio size="small" />} label="Enviar e-mail de alteração" />
+    </RadioGroup>
+  </Stack>
+);
+
+const SecaoSocial = ({ label, url, mensagem, link, igrejaId, canal }) => {
+  const [registrando, setRegistrando] = useState(false);
+  const [registrado, setRegistrado] = useState(false);
+  const [erro, setErro] = useState("");
+
+  const handleAbrir = () => {
+    const href = url.startsWith("http") ? url : `https://${url}`;
+    window.open(href, "_blank", "noopener,noreferrer");
+  };
+
+  const handleRegistrar = async () => {
+    setRegistrando(true);
+    setErro("");
+    try {
+      await api.post("/api/v1/Admin/email-evento/registrar-contato", {
+        igrejaId,
+        tipo: 99,
+        canal,
+        destinoContato: url,
+        dataEnvio: new Date().toISOString(),
+      });
+      setRegistrado(true);
+    } catch {
+      setErro("Não foi possível registrar o contato.");
+    } finally {
+      setRegistrando(false);
+    }
+  };
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant="subtitle2" fontWeight={600}>
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {url}
+      </Typography>
+
+      <Stack direction="row" spacing={1} flexWrap="wrap">
+        <Tooltip title="Copia a mensagem sugerida para a área de transferência">
+          <Button size="small" variant="outlined" startIcon={<ContentCopyIcon />} onClick={() => copiar(mensagem)}>
+            Copiar mensagem
+          </Button>
+        </Tooltip>
+        <Tooltip title="Copia o link da página da igreja">
+          <Button size="small" variant="outlined" startIcon={<LinkIcon />} onClick={() => copiar(link)}>
+            Copiar link
+          </Button>
+        </Tooltip>
+        <Button size="small" variant="outlined" startIcon={<OpenInNewIcon />} onClick={handleAbrir}>
+          Abrir {label}
+        </Button>
+      </Stack>
+
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 0.5 }}>
+        {registrado ? (
+          <Chip
+            icon={<CheckCircleIcon />}
+            label="Contato registrado"
+            color="success"
+            size="small"
+            variant="outlined"
+          />
+        ) : (
+          <Button
+            size="small"
+            variant="contained"
+            color="success"
+            onClick={handleRegistrar}
+            disabled={registrando}
+            startIcon={registrando ? <CircularProgress size={14} color="inherit" /> : null}
+          >
+            Registrar contato realizado
+          </Button>
+        )}
+        {erro && (
+          <Typography variant="caption" color="error">
+            {erro}
+          </Typography>
+        )}
+      </Stack>
+    </Stack>
+  );
+};
+
+const AssistenteDivulgacao = ({
+  open,
+  onClose,
+  igreja,
+  emailCriacaoEnviado,
+  urlInstagram,
+  urlFacebook,
+  loading,
+  opcaoEmail,
+  onOpcaoEmailChange,
+  onConfirmar,
+}) => {
+  const email = igreja?.contato?.emailContato?.trim() || "";
+  const nomeIgreja = igreja?.nome || "sua paróquia";
+  const igrejaId = igreja?.id;
+  const link = construirLinkIgreja(igreja);
+
+  const mensagemInstagram = gerarMensagemInstagram(nomeIgreja, link);
+  const mensagemFacebook = gerarMensagemFacebook(nomeIgreja, link);
+
+  const temSecao = email || urlInstagram || urlFacebook;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Divulgação da Igreja</DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          A igreja possui os seguintes canais cadastrados. Escolha quais contatos deseja realizar.
+        </Typography>
+
+        {!temSecao && (
+          <Typography variant="body2" color="text.secondary">
+            Nenhum canal de contato cadastrado.
+          </Typography>
+        )}
+
+        <Stack spacing={3} divider={<Divider />}>
+          {email && (
+            <SecaoEmail
+              email={email}
+              emailCriacaoEnviado={emailCriacaoEnviado}
+              opcao={opcaoEmail}
+              onChange={onOpcaoEmailChange}
+            />
+          )}
+
+          {urlInstagram && (
+            <SecaoSocial
+              label="Instagram"
+              url={urlInstagram}
+              mensagem={mensagemInstagram}
+              link={link}
+              igrejaId={igrejaId}
+              canal={2}
+            />
+          )}
+
+          {urlFacebook && (
+            <SecaoSocial
+              label="Facebook"
+              url={urlFacebook}
+              mensagem={mensagemFacebook}
+              link={link}
+              igrejaId={igrejaId}
+              canal={3}
+            />
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+        <Button variant="outlined" color="inherit" onClick={onClose} disabled={loading}>
+          Cancelar
+        </Button>
+        <Button variant="contained" onClick={onConfirmar} disabled={loading}>
+          Confirmar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AssistenteDivulgacao;

--- a/src/Igreja/Components/IgrejaContatosHistorico.jsx
+++ b/src/Igreja/Components/IgrejaContatosHistorico.jsx
@@ -1,0 +1,84 @@
+/* eslint-disable react/prop-types */
+import { useEffect, useState } from "react";
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import api from "../../services/apiService";
+
+// CanalContatoEnum: Email=1, Instagram=2, Facebook=3
+// TipoEmailEventoIgrejaEnum: Criacao=1, Alteracao=2, Notificacao=3, Validacao=4, Outro=99
+const CANAL_ICONE = { 1: "📧", 2: "📸", 3: "📘" };
+const CANAL_LABEL = { 1: "E-mail", 2: "Instagram", 3: "Facebook" };
+const TIPO_LABEL = {
+  1: "Criação",
+  2: "Alteração",
+  3: "Notificação",
+  4: "Validação",
+  99: "Contato manual",
+};
+
+const formatarData = (valor) => {
+  if (!valor) return "-";
+  return new Date(valor).toLocaleDateString("pt-BR");
+};
+
+const IgrejaContatosHistorico = ({ igrejaId }) => {
+  const [loading, setLoading] = useState(true);
+  const [contatos, setContatos] = useState([]);
+
+  useEffect(() => {
+    if (!igrejaId) return;
+
+    api
+      .get(`/api/v1/Admin/email-evento/igreja/${igrejaId}`)
+      .then((res) => {
+        const lista = res.data?.data || res.data || [];
+        setContatos(lista.slice(0, 10));
+      })
+      .catch(() => setContatos([]))
+      .finally(() => setLoading(false));
+  }, [igrejaId]);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+      <Typography variant="subtitle2" fontWeight={700} mb={1.5}>
+        Últimos contatos
+      </Typography>
+
+      {loading && (
+        <Box display="flex" justifyContent="center" py={2}>
+          <CircularProgress size={20} />
+        </Box>
+      )}
+
+      {!loading && contatos.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          Nenhum contato registrado.
+        </Typography>
+      )}
+
+      {!loading && contatos.length > 0 && (
+        <Stack divider={<Divider />} spacing={1}>
+          {contatos.map((c) => (
+            <Box key={c.id} sx={{ py: 0.5 }}>
+              <Typography variant="body2" fontWeight={500}>
+                {CANAL_ICONE[c.canal] ?? "📄"}{" "}
+                {CANAL_LABEL[c.canal] ?? "Contato"} de {TIPO_LABEL[c.tipo] ?? c.tipo}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatarData(c.dataEnvio || c.dataCriacao)}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Paper>
+  );
+};
+
+export default IgrejaContatosHistorico;

--- a/src/Igreja/IgrejaAtualizar.jsx
+++ b/src/Igreja/IgrejaAtualizar.jsx
@@ -8,11 +8,6 @@ import {
   FormControlLabel,
   CircularProgress,
   Stack,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
   Tabs,
   Tab,
 } from "@mui/material";
@@ -30,6 +25,8 @@ import RedesSociaisSection from "./Components/RedesSociaisSection";
 import SectionCard from "./Components/SectionCard";
 import IgrejasCepModal from "./Components/IgrejasCepModal";
 import IgrejaMetricasTab from "./Components/IgrejaMetricasTab";
+import AssistenteDivulgacao from "./Components/AssistenteDivulgacao";
+import IgrejaContatosHistorico from "./Components/IgrejaContatosHistorico";
 
 
 const IgrejaAtualizar = () => {
@@ -90,6 +87,9 @@ const IgrejaAtualizar = () => {
   const [igrejasEncontradasCep, setIgrejasEncontradasCep] = useState([]);
   const [emailContatoModalOpen, setEmailContatoModalOpen] = useState(false);
   const [abaAtiva, setAbaAtiva] = useState(0);
+
+  // Assistente de Divulgação
+  const [divulgacaoOpcaoEmail, setDivulgacaoOpcaoEmail] = useState("");
 
 
   // Carregar endereço do formData quando o componente monta
@@ -569,8 +569,10 @@ const IgrejaAtualizar = () => {
         });
   };
 
+  const urlInstagram = formDataRedeSociais.find((r) => r.tipoRedeSocial === 2)?.url || "";
+  const urlFacebook = formDataRedeSociais.find((r) => r.tipoRedeSocial === 1)?.url || "";
+
   const handleSubmit = () => {
-    // Verificar se existe pelo menos uma missa antes de prosseguir
     if (!formDatamissas || formDatamissas.length === 0) {
       setMessage({
         mensagem: "Erro: É necessário adicionar ao menos uma missa antes de editar a igreja!",
@@ -581,8 +583,10 @@ const IgrejaAtualizar = () => {
     }
 
     const emailContato = formData?.contato?.emailContato?.trim();
+    const temCanal = (emailContato || urlInstagram || urlFacebook) && formData?.ativo;
 
-    if (emailContato && formData?.ativo) {
+    if (temCanal) {
+      setDivulgacaoOpcaoEmail("");
       setEmailContatoModalOpen(true);
       return;
     }
@@ -861,6 +865,12 @@ const IgrejaAtualizar = () => {
       </SectionCard>
       )}
 
+      {abaAtiva === 0 && formData.id && (
+        <Box sx={{ mt: 2 }}>
+          <IgrejaContatosHistorico igrejaId={formData.id} />
+        </Box>
+      )}
+
       <IgrejasCepModal
           open={igrejasCepModalOpen}
           igrejas={igrejasEncontradasCep}
@@ -869,55 +879,18 @@ const IgrejaAtualizar = () => {
           onClose={() => setIgrejasCepModalOpen(false)}
           onEditar={handleEditarIgrejaCep}
       />
-      <Dialog
-          open={emailContatoModalOpen}
-          onClose={() => setEmailContatoModalOpen(false)}
-          fullWidth
-          maxWidth="sm"
-      >
-        <DialogTitle>Enviar e-mail de contato?</DialogTitle>
-
-        <DialogContent>
-          <DialogContentText>
-            Esta igreja possui e-mail de contato cadastrado. Deseja enviar um e-mail informando sobre criação ou alteração?
-          </DialogContentText>
-
-          <Typography variant="body2" sx={{ mt: 2, fontWeight: 600 }}>
-            E-mail: {formData?.contato?.emailContato}
-          </Typography>
-        </DialogContent>
-
-        <DialogActions sx={{ px: 3, pb: 2, gap: 1, flexWrap: "wrap" }}>
-          <Button
-              variant="outlined"
-              color="inherit"
-              onClick={() => atualizarIgreja()}
-              disabled={loading}
-          >
-            Não enviar
-          </Button>
-
-          {!formData.emailCriacaoEnviado && (
-            <Button
-                variant="outlined"
-                color="primary"
-                onClick={() => atualizarIgreja("criacao")}
-                disabled={loading}
-            >
-              Enviar criação
-            </Button>
-          )}
-
-          <Button
-              variant="contained"
-              color="primary"
-              onClick={() => atualizarIgreja("alteracao")}
-              disabled={loading}
-          >
-            Enviar alteração
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <AssistenteDivulgacao
+        open={emailContatoModalOpen}
+        onClose={() => setEmailContatoModalOpen(false)}
+        igreja={{ ...formData, endereco }}
+        emailCriacaoEnviado={formData?.emailCriacaoEnviado}
+        urlInstagram={urlInstagram}
+        urlFacebook={urlFacebook}
+        loading={loading}
+        opcaoEmail={divulgacaoOpcaoEmail}
+        onOpcaoEmailChange={setDivulgacaoOpcaoEmail}
+        onConfirmar={() => atualizarIgreja(divulgacaoOpcaoEmail || null)}
+      />
     </>
   );
 };

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -22,8 +22,8 @@ const LoginPage = () => {
 
   const handleLogin = async (e) => {
     e.preventDefault();
-    await login(email, senha);
-    if (isAuthenticated) {
+    const sucesso = await login(email, senha);
+    if (sucesso) {
       navigate("/home");
     }
   };

--- a/src/services/mensagemDivulgacao.js
+++ b/src/services/mensagemDivulgacao.js
@@ -1,0 +1,34 @@
+const BASE_URL = import.meta.env.VITE_PAROQUIA_BASE_URL?.replace(/\/+$/, "") ?? "https://buscamissa.com.br/paroquia";
+
+export const construirLinkIgreja = (igreja) => {
+  const uf = igreja?.endereco?.uf?.toLowerCase() || "";
+  const cidade = igreja?.endereco?.cidadeSlug || "";
+  const slug = igreja?.slug || "";
+  const partes = [BASE_URL, uf, cidade, slug].filter(Boolean);
+  return partes.join("/");
+};
+
+const MENSAGEM = (nomeIgreja, link) =>
+`Olá! Paz e bem! 🙏
+
+Criamos uma página para a ${nomeIgreja} no BuscaMissa com os horários de missa e outras informações da paróquia.
+
+Gostaríamos de convidá-los a conferir se os dados estão corretos. Caso encontrem alguma informação desatualizada ou que possa ser complementada, teremos a maior alegria em realizar as alterações para manter tudo sempre atualizado.
+
+📍 Acesse a página da paróquia:
+
+${link}
+
+O BuscaMissa é uma plataforma gratuita, criada para ajudar os fiéis a encontrarem horários de missas e informações das igrejas em todo o Brasil.
+
+Se gostarem da iniciativa, ficaremos muito felizes se puderem acompanhar nosso trabalho e compartilhar o projeto com a comunidade.
+
+📸 Instagram: https://instagram.com/buscamissa
+
+📘 Facebook: https://facebook.com/buscamissa
+
+Que Deus abençoe toda a comunidade! 🙏`;
+
+export const gerarMensagemInstagram = (nomeIgreja, link) => MENSAGEM(nomeIgreja, link);
+
+export const gerarMensagemFacebook = (nomeIgreja, link) => MENSAGEM(nomeIgreja, link);


### PR DESCRIPTION
## Summary

- **Tela Divulgação das Igrejas**: filtros (canal, tipo, nome da igreja, cidade, data de envio), colunas reformuladas com labels em português e ações rápidas (abrir rede social, copiar mensagem)
- **AssistenteDivulgacao**: popup pós-salvar com seções por canal (Email com radio group, Instagram e Facebook com botões de copiar mensagem, copiar link, abrir e registrar contato)
- **mensagemDivulgacao.js**: gerador de mensagem padronizado com nome e link público da paróquia
- **IgrejaContatosHistorico**: card "Últimos contatos" na aba Dados da edição da igreja
- **Fix**: redirect de login usando o retorno da função `login()` em vez de ler o state (corrige necessidade de segundo clique)

## Test plan

- [ ] Editar igreja com e-mail e redes sociais → popup abre com seções corretas
- [ ] "Copiar mensagem" copia texto com nome da igreja e link público correto
- [ ] "Registrar contato realizado" cria registro e exibe chip de confirmação
- [ ] Card "Últimos contatos" lista os registros na edição da igreja
- [ ] Tela Divulgação: filtros funcionam por canal, cidade e data
- [ ] Login redireciona imediatamente após 200 sem precisar de segundo clique

🤖 Generated with [Claude Code](https://claude.com/claude-code)