### PR TITLE
feat: filtros, reset de senha e igrejas por usuário

### DIFF
--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -262,6 +262,7 @@ const Menu = ({ children }) => {
           minHeight: "100vh",
           display: "flex",
           flexDirection: "column",
+          pt: { xs: `${TOP_BAR_HEIGHT}px`, sm: `${TOP_BAR_HEIGHT_SM}px`, md: 0 },
         }}
       >
         <Box

--- a/src/Usuario.jsx
+++ b/src/Usuario.jsx
@@ -15,7 +15,9 @@ import {
   DialogTitle,
   TextField,
   Checkbox,
+  MenuItem,
 } from "@mui/material";
+import Grid from "@mui/material/Grid2";
 import Menu from "./Components/Menu";
 import api from "./services/apiService";
 import { useState, useEffect } from "react";
@@ -24,7 +26,27 @@ import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import ManageAccountsIcon from "@mui/icons-material/ManageAccounts";
 import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
 import ContactEmergencyIcon from "@mui/icons-material/ContactEmergency";
+import SearchIcon from "@mui/icons-material/Search";
+import ClearIcon from "@mui/icons-material/Clear";
+import LockResetIcon from "@mui/icons-material/LockReset";
+import ChurchIcon from "@mui/icons-material/Church";
 import Pagination from "./Components/Paginacao";
+
+const PERFIS = [
+  { id: 1, nome: "Admin" },
+  { id: 2, nome: "App" },
+  { id: 3, nome: "Regular" },
+  { id: 4, nome: "Dono" },
+];
+
+const FILTROS_PADRAO = {
+  nome: "",
+  email: "",
+  perfil: "",
+  bloqueado: "",
+  criacaoInicio: "",
+  criacaoFim: "",
+};
 
 const UsuarioPage = () => {
   const [data, setData] = useState([]);
@@ -34,6 +56,14 @@ const UsuarioPage = () => {
   const [openDetailsModal, setOpenDetailsModal] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
   const [motivo, setMotivo] = useState("");
+  const [filtros, setFiltros] = useState({ ...FILTROS_PADRAO });
+  const [filtrosAplicados, setFiltrosAplicados] = useState({ ...FILTROS_PADRAO });
+  const [openSenhaModal, setOpenSenhaModal] = useState(false);
+  const [novaSenha, setNovaSenha] = useState("");
+  const [senhaError, setSenhaError] = useState("");
+  const [openIgrejasModal, setOpenIgrejasModal] = useState(false);
+  const [igrejasUsuario, setIgrejasUsuario] = useState([]);
+  const [igrejasLoading, setIgrejasLoading] = useState(false);
 
   const perfil = (idPerfil) => {
     switch (idPerfil) {
@@ -119,37 +149,24 @@ const UsuarioPage = () => {
     }
   };
 
-  useEffect(() => {
-    api
-      .get(
-        "/api/v1/Admin/usuario/buscar-por-filtro?Paginacao.PageIndex=1&Paginacao.PageSize=10"
-      )
-      .then((response) => {
-        setData(response.data.data.usuarios);
-        setPaginacao({
-          pageIndex: response.data.data.usuarios.pageIndex,
-          pageSize: response.data.data.usuarios.pageSize,
-          totalItems: response.data.data.usuarios.totalItems,
-          hasPreviousPage: response.data.data.usuarios.hasPreviousPage,
-          hasNextPage: response.data.data.usuarios.hasNextPage,
-          nextPage: response.data.data.usuarios.nextPage,
-          previousPage: response.data.data.usuarios.previousPage,
-          totalPages: response.data.data.usuarios.totalPages,
-        });
-      })
-      .catch((error) => {
-        console.error("Error fetching data:", error);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, []);
+  const buildQueryParams = (pageIndex, pageSize, aplicados) => {
+    const params = new URLSearchParams();
+    params.set("Paginacao.PageIndex", pageIndex);
+    params.set("Paginacao.PageSize", pageSize);
+    if (aplicados.nome) params.set("Nome", aplicados.nome);
+    if (aplicados.email) params.set("Email", aplicados.email);
+    if (aplicados.perfil) params.set("Perfil", aplicados.perfil);
+    if (aplicados.bloqueado !== "") params.set("Bloqueado", aplicados.bloqueado);
+    if (aplicados.criacaoInicio) params.set("CriacaoInicio", aplicados.criacaoInicio);
+    if (aplicados.criacaoFim) params.set("CriacaoFim", aplicados.criacaoFim);
+    return params.toString();
+  };
 
-  const fetchUsuarios = async (pageIndex = 1, pageSize = 10) => {
+  const fetchUsuarios = async (pageIndex = 1, pageSize = 10, aplicados = filtrosAplicados) => {
     setIsLoading(true);
     try {
       const response = await api.get(
-        `/api/v1/Admin/usuario/buscar-por-filtro?Paginacao.PageIndex=${pageIndex}&Paginacao.PageSize=${pageSize}`
+        `/api/v1/Admin/usuario/buscar-por-filtro?${buildQueryParams(pageIndex, pageSize, aplicados)}`
       );
       setData(response.data.data.usuarios);
       setPaginacao({
@@ -170,19 +187,177 @@ const UsuarioPage = () => {
   };
 
   useEffect(() => {
-    fetchUsuarios(paginacao.pageIndex, paginacao.pageSize);
-     
-  }, [paginacao.pageIndex, paginacao.pageSize]);
+    fetchUsuarios(1, 10, FILTROS_PADRAO);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handlePageChange = (newPageIndex) => {
-    setPaginacao((prev) => ({
-      ...prev,
-      pageIndex: newPageIndex,
-    }));
+    fetchUsuarios(newPageIndex, paginacao.pageSize, filtrosAplicados);
+  };
+
+  const handleFiltroChange = (campo) => (event) => {
+    setFiltros((prev) => ({ ...prev, [campo]: event.target.value }));
+  };
+
+  const handleAplicarFiltros = () => {
+    setFiltrosAplicados(filtros);
+    fetchUsuarios(1, paginacao.pageSize || 10, filtros);
+  };
+
+  const handleLimparFiltros = () => {
+    setFiltros({ ...FILTROS_PADRAO });
+    setFiltrosAplicados({ ...FILTROS_PADRAO });
+    fetchUsuarios(1, paginacao.pageSize || 10, FILTROS_PADRAO);
+  };
+
+  const handleOpenSenhaModal = (user) => {
+    setSelectedUser(user);
+    setNovaSenha("");
+    setSenhaError("");
+    setOpenSenhaModal(true);
+  };
+
+  const handleCloseSenhaModal = () => {
+    setOpenSenhaModal(false);
+    setSelectedUser(null);
+    setNovaSenha("");
+    setSenhaError("");
+  };
+
+  const handleConfirmResetarSenha = async () => {
+    if (!selectedUser) return;
+    if (novaSenha.length < 6) {
+      setSenhaError("A senha deve ter no mínimo 6 caracteres.");
+      return;
+    }
+    try {
+      await api.put(`/api/v1/Admin/usuario/resetar-senha/${selectedUser.id}`, {
+        novaSenha,
+      });
+      alert("Senha resetada com sucesso!");
+      handleCloseSenhaModal();
+    } catch (error) {
+      console.error("Erro ao resetar senha:", error);
+      alert("Erro ao resetar a senha. Tente novamente.");
+    }
+  };
+
+  const handleOpenIgrejasModal = async (user) => {
+    setSelectedUser(user);
+    setOpenIgrejasModal(true);
+    setIgrejasLoading(true);
+    try {
+      const response = await api.get(`/api/v1/Admin/usuario/${user.id}/igrejas`);
+      setIgrejasUsuario(response.data.data.igrejas);
+    } catch (error) {
+      console.error("Erro ao buscar igrejas do usuário:", error);
+      setIgrejasUsuario([]);
+    } finally {
+      setIgrejasLoading(false);
+    }
+  };
+
+  const handleCloseIgrejasModal = () => {
+    setOpenIgrejasModal(false);
+    setSelectedUser(null);
+    setIgrejasUsuario([]);
   };
 
   return (
     <Menu>
+      <Paper sx={{ p: 2, borderRadius: 2, mb: 2 }}>
+        <Grid container spacing={2} alignItems="center">
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Nome"
+              value={filtros.nome}
+              onChange={handleFiltroChange("nome")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Email"
+              value={filtros.email}
+              onChange={handleFiltroChange("email")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
+            <TextField
+              select
+              fullWidth
+              size="small"
+              label="Perfil"
+              value={filtros.perfil}
+              onChange={handleFiltroChange("perfil")}
+            >
+              <MenuItem value="">Todos</MenuItem>
+              {PERFIS.map((p) => (
+                <MenuItem key={p.id} value={p.id}>
+                  {p.nome}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
+            <TextField
+              select
+              fullWidth
+              size="small"
+              label="Bloqueado"
+              value={filtros.bloqueado}
+              onChange={handleFiltroChange("bloqueado")}
+            >
+              <MenuItem value="">Todos</MenuItem>
+              <MenuItem value="true">Sim</MenuItem>
+              <MenuItem value="false">Não</MenuItem>
+            </TextField>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Criado a partir de"
+              InputLabelProps={{ shrink: true }}
+              value={filtros.criacaoInicio}
+              onChange={handleFiltroChange("criacaoInicio")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 2 }}>
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Criado até"
+              InputLabelProps={{ shrink: true }}
+              value={filtros.criacaoFim}
+              onChange={handleFiltroChange("criacaoFim")}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="contained"
+                startIcon={<SearchIcon />}
+                onClick={handleAplicarFiltros}
+              >
+                Filtrar
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<ClearIcon />}
+                onClick={handleLimparFiltros}
+              >
+                Limpar
+              </Button>
+            </Stack>
+          </Grid>
+        </Grid>
+      </Paper>
       <TableContainer
         component={Paper}
         sx={{ p: 2, borderRadius: 2, overflow: "auto" }}
@@ -208,6 +383,7 @@ const UsuarioPage = () => {
                 <TableCell>Nome</TableCell>
                 <TableCell>Perfil</TableCell>
                 <TableCell>Bloqueado</TableCell>
+                <TableCell>Igrejas</TableCell>
                 <TableCell>Ações</TableCell>
               </TableRow>
             </TableHead>
@@ -218,6 +394,18 @@ const UsuarioPage = () => {
                   <TableCell>{row.nome}</TableCell>
                   <TableCell>{perfil(row.perfil)}</TableCell>
                   <TableCell>{row.bloqueado ? "Sim" : "Não"}</TableCell>
+                  <TableCell>
+                    <Tooltip title="Ver igrejas cadastradas por este usuário">
+                      <Button
+                        variant="text"
+                        size="small"
+                        startIcon={<ChurchIcon />}
+                        onClick={() => handleOpenIgrejasModal(row)}
+                      >
+                        {row.totalIgrejas ?? 0}
+                      </Button>
+                    </Tooltip>
+                  </TableCell>
                   <TableCell>
                     <Stack direction="row" spacing={1}>
                       <Button
@@ -242,6 +430,17 @@ const UsuarioPage = () => {
                           onClick={() => handleOpenModal(row)}
                         >
                           {row.bloqueado ? "Desbloquear" : "Bloquear"}
+                        </Button>
+                      </Tooltip>
+                      <Tooltip title="Definir uma nova senha para o usuário">
+                        <Button
+                          variant="outlined"
+                          color="warning"
+                          size="small"
+                          startIcon={<LockResetIcon />}
+                          onClick={() => handleOpenSenhaModal(row)}
+                        >
+                          Resetar senha
                         </Button>
                       </Tooltip>
                     </Stack>
@@ -352,6 +551,83 @@ const UsuarioPage = () => {
             disabled={!selectedUser?.bloqueado && !motivo}
           >
             Confirmar
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={openSenhaModal} onClose={handleCloseSenhaModal}>
+        <DialogTitle>Resetar Senha</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" mb={2}>
+            Definir uma nova senha para <strong>{selectedUser?.nome}</strong>{" "}
+            ({selectedUser?.email}).
+          </Typography>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Nova senha"
+            type="password"
+            fullWidth
+            value={novaSenha}
+            onChange={(e) => {
+              setNovaSenha(e.target.value);
+              setSenhaError("");
+            }}
+            error={!!senhaError}
+            helperText={senhaError}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseSenhaModal} color="secondary">
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleConfirmResetarSenha}
+            color="primary"
+            disabled={!novaSenha}
+          >
+            Confirmar
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={openIgrejasModal} onClose={handleCloseIgrejasModal} fullWidth maxWidth="sm">
+        <DialogTitle>
+          Igrejas cadastradas por {selectedUser?.nome}
+        </DialogTitle>
+        <DialogContent>
+          {igrejasLoading ? (
+            <Box display="flex" justifyContent="center" py={3}>
+              <CircularProgress size={32} />
+            </Box>
+          ) : igrejasUsuario.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" py={2}>
+              Este usuário ainda não cadastrou nenhuma igreja.
+            </Typography>
+          ) : (
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Nome</TableCell>
+                  <TableCell>UF</TableCell>
+                  <TableCell>Cidade</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {igrejasUsuario.map((igreja) => (
+                  <TableRow key={igreja.id}>
+                    <TableCell>{igreja.nome}</TableCell>
+                    <TableCell>{igreja.uf}</TableCell>
+                    <TableCell>{igreja.localidade}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseIgrejasModal} color="primary">
+            Fechar
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary
- Filtros de Nome, Email, Perfil, Bloqueado e período de criação na tela de Usuários
- Botão "Resetar senha" por usuário com modal dedicado (chama o novo endpoint do backend)
- Coluna "Igrejas" com contagem + modal listando nome/UF/cidade das igrejas cadastradas pelo usuário
- Corrige sobreposição da AppBar fixa do mobile com o topo do conteúdo

Depende do backend: https://github.com/FabioVeiga/buscamissa-backend/pull/85

## Test plan
- [x] Validado visualmente no mobile e desktop (filtros, coluna Igrejas, modais)
- [x] Testado ponta a ponta contra backend local + banco real de dev: login, filtros, reset de senha, modal de igrejas