### PR TITLE
feat: link para edição no popup de igrejas cadastradas pelo usuário

### DIFF
--- a/src/Usuario.jsx
+++ b/src/Usuario.jsx
@@ -16,11 +16,13 @@ import {
   TextField,
   Checkbox,
   MenuItem,
+  Link,
 } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import Menu from "./Components/Menu";
 import api from "./services/apiService";
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { CircularProgress, Box, Typography } from "@mui/material";
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import ManageAccountsIcon from "@mui/icons-material/ManageAccounts";
@@ -48,7 +50,33 @@ const FILTROS_PADRAO = {
   criacaoFim: "",
 };
 
+const buscarIgrejaCompletaPorId = async (id) => {
+  const response = await api.get(`/api/v2/Igreja/admin/${id}`);
+  return response.data?.data || response.data;
+};
+
+const normalizarIgrejaParaEdicao = (response) => {
+  const igreja = response?.igreja || response?.item || response?.data || response;
+  const endereco =
+    igreja?.endereco || igreja?.dadosEndereco || igreja?.dados?.endereco || response?.endereco || {};
+
+  return {
+    id: igreja?.id,
+    nome: igreja?.nome || "",
+    nomeUnico: igreja?.nomeUnico || "",
+    slug: igreja?.slug || "",
+    paroco: igreja?.paroco || "",
+    missas: igreja?.missas || [],
+    contato: igreja?.contato || {},
+    redesSociais: igreja?.redesSociais || [],
+    endereco,
+    ativo: igreja?.ativo ?? true,
+    imagemUrl: igreja?.imagemUrl || igreja?.imagem || "",
+  };
+};
+
 const UsuarioPage = () => {
+  const navigate = useNavigate();
   const [data, setData] = useState([]);
   const [paginacao, setPaginacao] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -261,6 +289,16 @@ const UsuarioPage = () => {
     setOpenIgrejasModal(false);
     setSelectedUser(null);
     setIgrejasUsuario([]);
+  };
+
+  const handleEditarIgreja = async (igrejaId) => {
+    try {
+      const igrejaCompleta = await buscarIgrejaCompletaPorId(igrejaId);
+      handleCloseIgrejasModal();
+      navigate("/igrejaEditar", { state: { row: normalizarIgrejaParaEdicao(igrejaCompleta) } });
+    } catch (error) {
+      console.error("Erro ao abrir igreja para edição:", error);
+    }
   };
 
   return (
@@ -615,8 +653,16 @@ const UsuarioPage = () => {
               </TableHead>
               <TableBody>
                 {igrejasUsuario.map((igreja) => (
-                  <TableRow key={igreja.id}>
-                    <TableCell>{igreja.nome}</TableCell>
+                  <TableRow key={igreja.id} hover>
+                    <TableCell>
+                      <Link
+                        component="button"
+                        underline="hover"
+                        onClick={() => handleEditarIgreja(igreja.id)}
+                      >
+                        {igreja.nome}
+                      </Link>
+                    </TableCell>
                     <TableCell>{igreja.uf}</TableCell>
                     <TableCell>{igreja.localidade}</TableCell>
                   </TableRow>


### PR DESCRIPTION
## Resumo
No popup "Igrejas cadastradas por {usuário}" (tela de Usuários), o nome da igreja agora é clicável e abre direto a tela de edição no Admin — mesmo padrão já usado na tela de Indicadores.

## Sobre o item 2 do pedido original (coluna "qual igreja o usuário alterou" quando aparece zero)
Investiguei o backend: o popup lista igrejas via `Igreja.UsuarioId`, preenchido **só quando o usuário cria/ativa** a igreja. O endpoint que o Admin usa para **editar** uma igreja (`PUT /api/v1/admin/igreja/atualizar`) não grava em nenhum lugar quem fez a edição — não existe log de auditoria nem coluna "última edição por" no banco hoje. Isso explica o "zero": são provavelmente contas de staff que editam igrejas de terceiros sem nunca aparecerem como "criadoras".

Implementar essa coluna exigiria uma mudança de schema (nova tabela/coluna de auditoria + gravação a cada PUT) — combinado que ficaria para uma etapa futura, então não faz parte deste PR.

## Test plan
- [x] Lint sem erros
- [x] Build de produção sem erros