### PR TITLE
fix: atalhos de período dos Indicadores usavam UTC em vez do dia local

### DIFF
--- a/src/Indicadores/Indicadores.jsx
+++ b/src/Indicadores/Indicadores.jsx
@@ -37,7 +37,14 @@ const TOP_N = 10;
 // Etapa 5: altura fixa para o scroll interno quando houver mais linhas do que cabe.
 const ALTURA_TABELA = 360;
 
-const paraDataInput = (data) => data.toISOString().slice(0, 10);
+// Usa os componentes de data LOCAIS do navegador — toISOString() converte para UTC
+// e "vira o dia" antes da hora, ex: 22h no Brasil (UTC-3) já é o dia seguinte em UTC.
+const paraDataInput = (data) => {
+  const ano = data.getFullYear();
+  const mes = String(data.getMonth() + 1).padStart(2, "0");
+  const dia = String(data.getDate()).padStart(2, "0");
+  return `${ano}-${mes}-${dia}`;
+};
 
 // Atalhos de período — usados tanto no botão de atalho quanto no default inicial (competência atual).
 const periodoHoje = () => {


### PR DESCRIPTION
## Resumo
Bug reportado: às 22:38 de 06/07/2026 (horário do Brasil), a tela de Indicadores em produção já aparecia zerada.

Causa raiz: `paraDataInput()` usava `data.toISOString().slice(0, 10)`, que converte para UTC antes de extrair a data. Às 21h-23h59 no Brasil (UTC-3), o dia em UTC já virou o dia seguinte — então o botão "Hoje" (e "Ontem"/"Mês corrente"/"Ano corrente", e o filtro padrão de abertura da tela) calculavam `dataInicial=dataFinal=07/07` em vez de `06/07`, e como não havia dado nenhum para "amanhã", a tela mostrava tudo zerado.

É o mesmo tipo de bug de fuso já corrigido no backend em https://github.com/FabioVeiga/buscamissa-backend/pull/90, só que reintroduzido no frontend ao implementar os atalhos de período.

## Correção
`paraDataInput()` agora monta a string `yyyy-MM-dd` a partir dos componentes de data locais (`getFullYear`/`getMonth`/`getDate`), sem nenhuma conversão de fuso.

## Test plan
- [x] Reproduzido o bug e validado o fix com um teste manual simulando 06/07/2026 22:38 (retornava `2026-07-07` antes, `2026-07-06` depois)
- [x] Lint sem erros
- [x] Build de produção sem erros