### PR TITLE
feat: melhorias na tela de Igrejas e Divulgação do admin

### DIFF
--- a/src/EmailEvento/EmailEvento.jsx
+++ b/src/EmailEvento/EmailEvento.jsx
@@ -26,12 +26,14 @@ import {
   Typography,
   IconButton,
   Tooltip,
+  Link,
 } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import PhoneCallbackIcon from "@mui/icons-material/PhoneCallback";
 import SendIcon from "@mui/icons-material/Send";
+import { useNavigate } from "react-router-dom";
 import Menu from "../Components/Menu";
 import Pagination from "../Components/Paginacao";
 import api from "../services/apiService";
@@ -69,7 +71,33 @@ const abrirUrl = (url) => {
 
 const copiar = (texto) => navigator.clipboard.writeText(texto).catch(() => {});
 
+const buscarIgrejaCompletaPorId = async (id) => {
+  const response = await api.get(`/api/v2/Igreja/admin/${id}`);
+  return response.data?.data || response.data;
+};
+
+const normalizarIgrejaParaEdicao = (response) => {
+  const igreja = response?.igreja || response?.item || response?.data || response;
+  const endereco =
+    igreja?.endereco || igreja?.dadosEndereco || igreja?.dados?.endereco || response?.endereco || {};
+
+  return {
+    id: igreja?.id,
+    nome: igreja?.nome || "",
+    nomeUnico: igreja?.nomeUnico || "",
+    slug: igreja?.slug || "",
+    paroco: igreja?.paroco || "",
+    missas: igreja?.missas || [],
+    contato: igreja?.contato || {},
+    redesSociais: igreja?.redesSociais || [],
+    endereco,
+    ativo: igreja?.ativo ?? true,
+    imagemUrl: igreja?.imagemUrl || igreja?.imagem || "",
+  };
+};
+
 const EmailEventoPage = () => {
+  const navigate = useNavigate();
   const [dashboard, setDashboard] = useState(null);
   const [dashboardLoading, setDashboardLoading] = useState(true);
 
@@ -251,6 +279,15 @@ const EmailEventoPage = () => {
   const toggleSelecionado = (id) =>
     setSelecionados((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
 
+  const handleEditarIgreja = async (igrejaId) => {
+    try {
+      const igrejaCompleta = await buscarIgrejaCompletaPorId(igrejaId);
+      navigate("/igrejaEditar", { state: { row: normalizarIgrejaParaEdicao(igrejaCompleta) } });
+    } catch {
+      setMessage({ mensagem: "Não foi possível abrir a igreja para edição.", severity: "error", show: true });
+    }
+  };
+
   return (
     <Menu>
       <Stack spacing={2}>
@@ -405,7 +442,11 @@ const EmailEventoPage = () => {
                               />
                             </TableCell>
                           )}
-                          <TableCell>{ig.nome}</TableCell>
+                          <TableCell>
+                            <Link component="button" underline="hover" onClick={() => handleEditarIgreja(ig.id)}>
+                              {ig.nome}
+                            </Link>
+                          </TableCell>
                           <TableCell>{[ig.cidade, ig.uf?.toUpperCase()].filter(Boolean).join(" / ") || "-"}</TableCell>
                           {modo === "SemContatoEmail" && (
                             <>

--- a/src/Igreja/Components/MissaForm.jsx
+++ b/src/Igreja/Components/MissaForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
     Box,
     TextField,
@@ -30,12 +30,14 @@ import SectionCard from "./SectionCard";
 const MissaForm = ({ missas = [], setMissas, onError }) => {
     const [novaMissa, setNovaMissa] = useState({ horario: "", diaSemana: [], observacao: "" });
     const [apoio, setApoio] = useState("");
+    const horarioRef = useRef(null);
 
     // Múltiplos horários
     const [multiOpen, setMultiOpen] = useState(false);
     const [multiDia, setMultiDia] = useState(0); // Domingo
     const [multiHorario, setMultiHorario] = useState("");
     const [multiHorarios, setMultiHorarios] = useState([]);
+    const multiHorarioRef = useRef(null);
 
     const handleChange = (field, value) => {
         setNovaMissa((prev) => ({ ...prev, [field]: value }));
@@ -72,6 +74,7 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
 
         setMissas((prev) => [...prev, ...novasMissas]);
         setNovaMissa({ horario: "", diaSemana: [], observacao: "" });
+        horarioRef.current?.focus();
     };
 
     const handleDeleteMissa = (indexToDelete) => {
@@ -83,6 +86,7 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
         if (multiHorarios.includes(multiHorario)) return;
         setMultiHorarios((prev) => [...prev, multiHorario]);
         setMultiHorario("");
+        multiHorarioRef.current?.focus();
     };
 
     const handleConfirmarMultiHorarios = () => {
@@ -118,6 +122,7 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
                     <TextField
                         label="Horário"
                         type="time"
+                        inputRef={horarioRef}
                         value={novaMissa.horario}
                         onChange={(e) => handleChange("horario", e.target.value)}
                         sx={{ width: 150 }}
@@ -164,6 +169,7 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
                             <TextField
                                 label="Horário"
                                 type="time"
+                                inputRef={multiHorarioRef}
                                 value={multiHorario}
                                 onChange={(e) => setMultiHorario(e.target.value)}
                                 sx={{ width: 150 }}

--- a/src/Igreja/IgrejaAtualizar.jsx
+++ b/src/Igreja/IgrejaAtualizar.jsx
@@ -12,6 +12,11 @@ import {
   Tab,
   Alert,
   AlertTitle,
+  Link,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from "@mui/material";
 import { ArrowBack } from "@mui/icons-material";
 import api from "../services/apiService";
@@ -30,6 +35,8 @@ import ReportarProblemaModal from "./Components/ReportarProblemaModal";
 import IgrejaMetricasTab from "./Components/IgrejaMetricasTab";
 import AssistenteDivulgacao from "./Components/AssistenteDivulgacao";
 import IgrejaContatosHistorico from "./Components/IgrejaContatosHistorico";
+import { construirLinkIgreja } from "../services/mensagemDivulgacao";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
 
 const IgrejaAtualizar = () => {
@@ -76,6 +83,7 @@ const IgrejaAtualizar = () => {
   });
 
   const [message, setMessage] = useState(errorMensage);
+  const [confirmarSemMissaAberto, setConfirmarSemMissaAberto] = useState(false);
   const [formDatamissas, setformDataMissas] = useState(state?.row?.missas || []);
   const [missas, setMissas] = useState([]);
   const [base64, setBase64] = useState("");
@@ -614,13 +622,15 @@ const IgrejaAtualizar = () => {
 
   const handleSubmit = () => {
     if (!formDatamissas || formDatamissas.length === 0) {
-      setMessage({
-        mensagem: "Erro: É necessário adicionar ao menos uma missa antes de editar a igreja!",
-        severity: "error",
-        show: true,
-      });
+      setConfirmarSemMissaAberto(true);
       return;
     }
+
+    prosseguirAposValidarMissas();
+  };
+
+  const prosseguirAposValidarMissas = () => {
+    setConfirmarSemMissaAberto(false);
 
     const emailContato = formData?.contato?.emailContato?.trim();
     const temCanal = (emailContato || urlInstagram || urlFacebook) && formData?.ativo;
@@ -658,6 +668,24 @@ const IgrejaAtualizar = () => {
           </AlertTitle>
           {state.row.reportarProblema.descricao}
         </Alert>
+      )}
+
+      {formData.nomeUnico && (
+        <Box sx={{ mb: 2, display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Página no site:
+          </Typography>
+          <Link
+            href={construirLinkIgreja({ ...formData, endereco })}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="body2"
+            sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+          >
+            {construirLinkIgreja({ ...formData, endereco })}
+            <OpenInNewIcon fontSize="inherit" />
+          </Link>
+        </Box>
       )}
 
       <Tabs
@@ -858,12 +886,13 @@ const IgrejaAtualizar = () => {
               <Box
                 component="img"
                 src={
-                  base64 ? `${imagemMimeType};base64,${base64}` : formData.imagemUrl
+                  base64 ? `data:${imagemMimeType};base64,${base64}` : formData.imagemUrl
                 }
                 alt="Preview"
                 sx={{
                   maxWidth: "100%",
-                  maxHeight: "400px",
+                  maxHeight: "200px",
+                  objectFit: "contain",
                   border: "1px solid #ccc",
                   borderRadius: 1,
                 }}
@@ -991,6 +1020,19 @@ const IgrejaAtualizar = () => {
           onSuccess={() => setModalReportarProblemaOpen(false)}
         />
       )}
+
+      <Dialog open={confirmarSemMissaAberto} onClose={() => setConfirmarSemMissaAberto(false)}>
+        <DialogTitle>Salvar sem missa?</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Nenhuma missa está cadastrada para esta igreja. Deseja continuar e salvar mesmo assim?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmarSemMissaAberto(false)}>Cancelar</Button>
+          <Button variant="contained" onClick={prosseguirAposValidarMissas}>Continuar sem missa</Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/src/Igreja/IgrejaCriar.jsx
+++ b/src/Igreja/IgrejaCriar.jsx
@@ -6,6 +6,10 @@ import {
   Typography,
   CircularProgress,
   Stack,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
 } from "@mui/material";
 import { ArrowBack } from "@mui/icons-material";
 import api from "../services/apiService";
@@ -24,6 +28,7 @@ import IgrejasCepModal from "./Components/IgrejasCepModal";
 const IgrejaCriar = () => {
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
+  const [confirmarSemMissaAberto, setConfirmarSemMissaAberto] = useState(false);
 
   const [formData, setFormData] = useState({
     nome: "",
@@ -47,6 +52,7 @@ const IgrejaCriar = () => {
   const [redeSociais, setRedeSociais] = useState([]);
   const [base64, setBase64] = useState("");
   const [fileName, setFileName] = useState("");
+  const [imagemMimeType, setImagemMimeType] = useState("image/png");
   const [urlInput, setUrlInput] = useState("");
 
   const [openCepReverso, setOpenCepReverso] = useState(false);
@@ -396,6 +402,7 @@ const IgrejaCriar = () => {
         const base64String = e.target.result.split(",")[1]; // Remove o cabeçalho 'data:image/jpeg;base64,'
         setBase64(base64String);
         setFileName(file.name);
+        setImagemMimeType(file.type || "image/png");
       };
 
       reader.readAsDataURL(file); // Lê o arquivo como uma DataURL
@@ -411,6 +418,7 @@ const IgrejaCriar = () => {
           const base64String = e.target.result.split(",")[1];
           setBase64(base64String);
           setFileName(name || "image");
+          setImagemMimeType(blob.type || "image/png");
           resolve(base64String);
         } catch (err) {
           reject(err);
@@ -432,10 +440,6 @@ const IgrejaCriar = () => {
       arrayAux.push("O campo Nome é obrigatório!")
     }
 
-    if (missas.length === 0) {
-      arrayAux.push("É necessário adicionar ao menos uma missa!")
-    }
-
     if (endereco === undefined) {
       arrayAux.push("É necessário ter o endereço preenchido!")
 
@@ -447,6 +451,16 @@ const IgrejaCriar = () => {
       return;
     }
 
+    if (missas.length === 0) {
+      setConfirmarSemMissaAberto(true);
+      return;
+    }
+
+    salvarIgreja();
+  };
+
+  const salvarIgreja = () => {
+    setConfirmarSemMissaAberto(false);
     setLoading(true);
 
     formData.missas = missas;
@@ -665,10 +679,12 @@ const IgrejaCriar = () => {
               {base64 && (
                   <Box
                       component="img"
-                      src={`data:image/png;base64,${base64}`}
+                      src={`data:${imagemMimeType};base64,${base64}`}
                       alt="Preview"
                       sx={{
                         maxWidth: "100%",
+                        maxHeight: "200px",
+                        objectFit: "contain",
                         border: "1px solid #ccc",
                         borderRadius: 2,
                       }}
@@ -759,6 +775,19 @@ const IgrejaCriar = () => {
             onClose={() => setIgrejasCepModalOpen(false)}
             onEditar={handleEditarIgrejaCep}
         />
+
+        <Dialog open={confirmarSemMissaAberto} onClose={() => setConfirmarSemMissaAberto(false)}>
+          <DialogTitle>Cadastrar sem missa?</DialogTitle>
+          <DialogContent>
+            <Typography variant="body2">
+              Nenhuma missa foi adicionada. Deseja continuar e cadastrar a igreja mesmo assim?
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setConfirmarSemMissaAberto(false)}>Cancelar</Button>
+            <Button variant="contained" onClick={salvarIgreja}>Continuar sem missa</Button>
+          </DialogActions>
+        </Dialog>
       </>
   );
 };


### PR DESCRIPTION
## Resumo
Ajustes solicitados no módulo Admin (Igrejas e Divulgação):

1. **Cadastrar/editar sem missa**: em vez de bloquear, mostra modal de confirmação perguntando se deseja continuar sem missa (Criar e Editar). Não havia validação equivalente no backend — o bloqueio era só no cliente.
2. **Preview de imagem**: corrigido em dois pontos
   - Editar: faltava o prefixo `data:` na data URI (`${imagemMimeType};base64,...` em vez de `data:${imagemMimeType};base64,...`) — o preview nunca funcionava, em nenhum formato.
   - Criar: tipo MIME fixo em `image/png`, quebrava para JPEG/outros formatos — agora captura o `file.type`/`blob.type` real.
   - Reduzido o tamanho do preview (200px, `object-fit: contain`) nos dois.
3. **Foco no campo Horário**: após adicionar uma missa (normal ou múltiplos horários), o foco volta pro campo de horário, agilizando cadastro de vários horários seguidos.
4. **Link da página do site**: exibido na tela de Editar Igreja (ex: `https://buscamissa.com.br/paroquia/sp/conchal/comunidade-mae-rainha`), reaproveitando o helper `construirLinkIgreja` já usado na Divulgação.
5. **Link de e-mail quebrado ao trocar nome**: causa raiz no backend — `IgrejaService.EditarAsync` regenerava `Slug`/`NomeUnico` a cada edição, então mudar o nome mudava a URL pública e quebrava qualquer link já enviado por e-mail. Corrigido para só gerar esses campos quando ainda estiverem vazios (ver PR companheiro no backend).
6. **Divulgação — link de edição**: nome da igreja na tabela agora é clicável e abre a edição direto.
7. **Filtro "Sem contato via e-mail"**: corrigido no backend — o filtro checava `EmailContato != null`, mas igrejas sem e-mail cadastrado ficam com string vazia (não null), passando pelo filtro incorretamente. Trocado para `!string.IsNullOrWhiteSpace(...)` (ver PR companheiro no backend).

## Dependência
Itens 5 e 7 dependem do PR do backend (correção de `EditarAsync` e `DivulgacaoService`).

## Test plan
- [x] Lint sem erros novos (erros pré-existentes no arquivo não relacionados a esta mudança)
- [x] Build de produção sem erros
- [ ] Teste manual end-to-end com o backend do PR companheiro rodando localmente