### PR TITLE
feat: aplicar endereço real (ViaCEP) direto no formulário ao buscar por CEP

### DIFF
--- a/src/Igreja/Components/IgrejasCepModal.jsx
+++ b/src/Igreja/Components/IgrejasCepModal.jsx
@@ -1,4 +1,6 @@
+/* eslint-disable react/prop-types */
 import {
+    Box,
     Button,
     Dialog,
     DialogActions,
@@ -17,8 +19,10 @@ import {
 const IgrejasCepModal = ({
                              open,
                              igrejas = [],
+                             endereco = null,
                              onClose,
                              onEditar,
+                             onUsarEndereco,
                              loading = false,
                              igrejaAtualId,
                          }) => {
@@ -30,6 +34,32 @@ const IgrejasCepModal = ({
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                     Selecione uma igreja abaixo para abrir a tela de edição.
                 </Typography>
+
+                {endereco && onUsarEndereco && (
+                    <Paper
+                        variant="outlined"
+                        sx={{ p: 2, borderRadius: 2, mb: 2, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, flexWrap: "wrap" }}
+                    >
+                        <Box>
+                            <Typography variant="subtitle2" fontWeight={700}>
+                                Endereço encontrado para este CEP
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                                {[endereco.logradouro, endereco.bairro, endereco.localidade, endereco.uf]
+                                    .filter(Boolean)
+                                    .join(", ") || "Endereço sem logradouro específico (CEP genérico)."}
+                            </Typography>
+                        </Box>
+                        <Button
+                            variant="contained"
+                            size="small"
+                            disabled={loading}
+                            onClick={() => onUsarEndereco(endereco)}
+                        >
+                            Usar este endereço
+                        </Button>
+                    </Paper>
+                )}
 
                 <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
                     <Table size="small">

--- a/src/Igreja/IgrejaAtualizar.jsx
+++ b/src/Igreja/IgrejaAtualizar.jsx
@@ -100,6 +100,7 @@ const IgrejaAtualizar = () => {
   const [igrejasCepModalOpen, setIgrejasCepModalOpen] = useState(false);
   const [modalReportarProblemaOpen, setModalReportarProblemaOpen] = useState(false);
   const [igrejasEncontradasCep, setIgrejasEncontradasCep] = useState([]);
+  const [enderecoResolvidoCep, setEnderecoResolvidoCep] = useState(null);
   const [emailContatoModalOpen, setEmailContatoModalOpen] = useState(false);
   const [divulgarAvulso, setDivulgarAvulso] = useState(false);
   const [abaAtiva, setAbaAtiva] = useState(0);
@@ -193,6 +194,7 @@ const IgrejaAtualizar = () => {
 
       if (Array.isArray(igrejas) && igrejas.length > 0) {
         setIgrejasEncontradasCep(igrejas);
+        setEnderecoResolvidoCep(igrejas[0]?.dadosEndereco || null);
         setIgrejasCepModalOpen(true);
         return;
       }
@@ -238,6 +240,18 @@ const IgrejaAtualizar = () => {
     } finally {
       setCepLoading(false);
     }
+  };
+
+  // Aplica o endereço real (resolvido via ViaCEP) direto no formulário da igreja
+  // atual, sem precisar navegar para nenhuma das igrejas listadas no modal.
+  const handleUsarEnderecoCep = (enderecoResponse) => {
+    preencherEndereco(enderecoResponse);
+    setIgrejasCepModalOpen(false);
+    setMessage({
+      mensagem: "Endereço aplicado. Confira os campos antes de salvar.",
+      severity: "success",
+      show: true,
+    });
   };
 
   const preencherEndereco = (enderecoResponse, cepFallback = "") => {
@@ -991,10 +1005,12 @@ const IgrejaAtualizar = () => {
       <IgrejasCepModal
           open={igrejasCepModalOpen}
           igrejas={igrejasEncontradasCep}
+          endereco={enderecoResolvidoCep}
           loading={cepLoading}
           igrejaAtualId={formData.id}
           onClose={() => setIgrejasCepModalOpen(false)}
           onEditar={handleEditarIgrejaCep}
+          onUsarEndereco={handleUsarEnderecoCep}
       />
       <AssistenteDivulgacao
         open={emailContatoModalOpen}

--- a/src/Igreja/IgrejaCriar.jsx
+++ b/src/Igreja/IgrejaCriar.jsx
@@ -62,6 +62,7 @@ const IgrejaCriar = () => {
   const [cepReversoError, setCepReversoError] = useState("");
   const [igrejasCepModalOpen, setIgrejasCepModalOpen] = useState(false);
   const [igrejasEncontradasCep, setIgrejasEncontradasCep] = useState([]);
+  const [enderecoResolvidoCep, setEnderecoResolvidoCep] = useState(null);
 
   const { endereco, setEndereco } = useEndereco();
   const enderecoAtual = endereco || {};
@@ -218,6 +219,7 @@ const IgrejaCriar = () => {
 
       if (Array.isArray(igrejas) && igrejas.length > 0) {
         setIgrejasEncontradasCep(igrejas);
+        setEnderecoResolvidoCep(igrejas[0]?.dadosEndereco || null);
         setIgrejasCepModalOpen(true);
         return;
       }
@@ -247,6 +249,14 @@ const IgrejaCriar = () => {
     } finally {
       setCepLoading(false);
     }
+  };
+
+  // Aplica o endereço real (resolvido via ViaCEP) direto no formulário, sem
+  // precisar navegar para nenhuma das igrejas listadas no modal.
+  const handleUsarEnderecoCep = (enderecoResponse) => {
+    preencherEndereco(enderecoResponse);
+    setIgrejasCepModalOpen(false);
+    setMessage(["Endereço aplicado. Confira os campos antes de salvar."]);
   };
 
   const handleGeocode = async () => {
@@ -771,9 +781,11 @@ const IgrejaCriar = () => {
         <IgrejasCepModal
             open={igrejasCepModalOpen}
             igrejas={igrejasEncontradasCep}
+            endereco={enderecoResolvidoCep}
             loading={cepLoading}
             onClose={() => setIgrejasCepModalOpen(false)}
             onEditar={handleEditarIgrejaCep}
+            onUsarEndereco={handleUsarEnderecoCep}
         />
 
         <Dialog open={confirmarSemMissaAberto} onClose={() => setConfirmarSemMissaAberto(false)}>


### PR DESCRIPTION
## Resumo
No modal "Igrejas encontradas para este CEP" (Criar e Editar Igreja), o endpoint `buscar-por-cep` já consultava o ViaCEP para resolver o endereço real daquele CEP, mas esse dado era descartado sempre que existiam igrejas cadastradas com o mesmo CEP — só sobrava a opção de navegar até a edição de uma delas.

Agora o modal também mostra o endereço resolvido (logradouro, bairro, cidade, UF) com um botão **"Usar este endereço"**, que aplica os campos direto na igreja que está sendo criada/editada — sem precisar navegar para nenhuma das igrejas listadas.

Nenhuma mudança de backend foi necessária: o dado já vinha na resposta (`dadosEndereco`), só não estava sendo aproveitado no frontend.

## Test plan
- [x] Lint sem erros novos no componente alterado
- [x] Build de produção sem erros
- [ ] Teste manual: buscar um CEP que tenha igrejas cadastradas e confirmar que o endereço aparece e é aplicado corretamente ao clicar em "Usar este endereço"