### PR TITLE
feat: admin ignora cache de endereços ao buscar cidades/bairros

### DIFF
--- a/src/Igreja/Components/EnderecoForm.jsx
+++ b/src/Igreja/Components/EnderecoForm.jsx
@@ -43,7 +43,9 @@ const EnderecoForm = ({
             setEnderecosLoading(true);
 
             try {
-                const response = await api.get("/api/v1/Igreja/v2/obter-enderecos");
+                // ignorarCache: no admin precisamos ver imediatamente cidades/bairros recém
+                // ajustados, sem esperar o TTL de 10 minutos do cache do backend.
+                const response = await api.get("/api/v1/Igreja/v2/obter-enderecos", { params: { ignorarCache: true } });
                 const data = response.data?.data || response.data || {};
 
                 setEnderecosMap(data && typeof data === "object" ? data : {});

--- a/src/Igreja/IgrejaSearchForm.jsx
+++ b/src/Igreja/IgrejaSearchForm.jsx
@@ -66,8 +66,10 @@ const IgrejaSearchForm = ({
 
   useEffect(() => {
     // Busca o mapa de endereços (UF -> Cidades -> Bairros)
+    // ignorarCache: no admin precisamos ver imediatamente cidades/bairros recém
+    // ajustados, sem esperar o TTL de 10 minutos do cache do backend.
     api
-      .get(`/api/v1/Igreja/v2/obter-enderecos`)
+      .get(`/api/v1/Igreja/v2/obter-enderecos`, { params: { ignorarCache: true } })
       .then((response) => {
         const data = response.data?.data || {};
         setEnderecosMap(data);


### PR DESCRIPTION
## Resumo
O endpoint `GET /api/v1/Igreja/v2/obter-enderecos` cacheia o resultado por 10 minutos (`IMemoryCache`, sem invalidação ativa). Isso atrasava a visibilidade de ajustes feitos no Admin — uma cidade/bairro novo só aparecia nos dropdowns depois do TTL expirar.

Companheiro do [PR do backend](https://github.com/FabioVeiga/buscamissa-backend/pull/95) (novo parâmetro opcional `ignorarCache`). As duas chamadas do admin (`EnderecoForm.jsx`, `IgrejaSearchForm.jsx`) agora passam `ignorarCache: true`.

Nenhuma mudança de comportamento para o site público, que continua chamando sem o parâmetro (cache normal).

## Test plan
- [x] Lint sem erros novos
- [x] Build de produção sem erros
- [ ] Teste manual: editar endereço de uma igreja e confirmar que a cidade/bairro aparece imediatamente no dropdown do admin, sem esperar 10 min