### PR TITLE
feat: Problemas Reportados, apoio no endereço, ações em lote nas missas e contador de sessão

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import Contribuidores from './Contribuidores';
 import EmailEventoPage from './EmailEvento/EmailEvento';
 import Indicadores from './Indicadores/Indicadores';
 import Aprovacoes from './Aprovacoes/Aprovacoes';
+import ReportarProblemaPage from './ReportarProblema/ReportarProblema';
 import PrivateRoute from './PrivateRoute'
 
 
@@ -98,6 +99,14 @@ const App = () => {
                 element={
                     <PrivateRoute isAuthenticated={isAuthenticated} loading={loading}>
                         <Aprovacoes />
+                    </PrivateRoute>
+                }
+            />
+            <Route
+                path="/reportar-problema"
+                element={
+                    <PrivateRoute isAuthenticated={isAuthenticated} loading={loading}>
+                        <ReportarProblemaPage />
                     </PrivateRoute>
                 }
             />

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -15,6 +15,7 @@ import {
   useMediaQuery,
 } from "@mui/material";
 import { useAuth } from "../Context/AuthContext";
+import SessaoCountdown from "./SessaoCountdown";
 import { useNavigate, useLocation } from "react-router-dom";
 import HomeIcon from "@mui/icons-material/Home";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
@@ -25,6 +26,7 @@ import CurrencyExchangeIcon from "@mui/icons-material/CurrencyExchange";
 import EmailIcon from "@mui/icons-material/Email";
 import InsightsIcon from "@mui/icons-material/Insights";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
+import AnnouncementIcon from "@mui/icons-material/Announcement";
 import MenuIcon from "@mui/icons-material/Menu";
 import CloseIcon from "@mui/icons-material/Close";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -41,6 +43,7 @@ const navItems = [
   { path: "/usuario", label: "Usuários", icon: AccountCircleIcon },
   { path: "/igreja", label: "Igrejas", icon: ChurchIcon },
   { path: "/aprovacoes", label: "Aprovações Pendentes", icon: FactCheckIcon },
+  { path: "/reportar-problema", label: "Problemas Reportados", icon: AnnouncementIcon },
   { path: "/solicitacoes", label: "Solicitações", icon: BuildIcon },
   { path: "/contribuidores", label: "Contribuidores", icon: CurrencyExchangeIcon },
   { path: "/email-evento", label: "Divulgação", icon: EmailIcon },
@@ -52,6 +55,7 @@ const pageTitles = {
   "/usuario": "Usuários",
   "/igreja": "Igrejas",
   "/aprovacoes": "Aprovações Pendentes",
+  "/reportar-problema": "Problemas Reportados",
   "/solicitacoes": "Solicitações",
   "/contribuidores": "Contribuidores",
   "/igrejaNovo": "Nova Igreja",
@@ -158,6 +162,11 @@ const Menu = ({ children }) => {
         })}
       </List>
       <Box sx={{ flex: 1 }} />
+      {(desktopOpen || isMobile) && (
+        <Box sx={{ px: 2, pt: 1 }}>
+          <SessaoCountdown />
+        </Box>
+      )}
       <List sx={{ px: 1.5, py: 1, borderTop: "1px solid rgba(255,255,255,0.08)" }}>
         <ListItem disablePadding>
           <ListItemButton

--- a/src/Components/RedirectModal.jsx
+++ b/src/Components/RedirectModal.jsx
@@ -28,7 +28,7 @@ const RedirectModal = ({ targetPage, state }) => {
           top: "50%",
           left: "50%",
           transform: "translate(-50%, -50%)",
-          width: 400,
+          width: "min(400px, 92vw)",
           bgcolor: "background.paper",
           border: "2px solid #000",
           boxShadow: 24,

--- a/src/Components/SessaoCountdown.jsx
+++ b/src/Components/SessaoCountdown.jsx
@@ -1,0 +1,64 @@
+/* eslint-disable react/prop-types */
+import { useEffect, useState } from "react";
+import { Typography } from "@mui/material";
+import { useAuth } from "../Context/AuthContext";
+
+const formatarRestante = (ms) => {
+  if (ms <= 0) return "00:00";
+  const totalSegundos = Math.floor(ms / 1000);
+  const horas = Math.floor(totalSegundos / 3600);
+  const minutos = Math.floor((totalSegundos % 3600) / 60);
+  const segundos = totalSegundos % 60;
+  const mm = String(minutos).padStart(2, "0");
+  const ss = String(segundos).padStart(2, "0");
+  return horas > 0 ? `${horas}:${mm}:${ss}` : `${mm}:${ss}`;
+};
+
+// Contador regressivo até a expiração do token (localStorage.user.acessToken.expira),
+// já preenchido pelo backend no login. Desloga automaticamente ao zerar.
+const SessaoCountdown = ({ compacto = false }) => {
+  const { user, logout } = useAuth();
+  const [restante, setRestante] = useState(null);
+
+  const expiraEm = user?.acessToken?.expira;
+
+  useEffect(() => {
+    if (!expiraEm) {
+      setRestante(null);
+      return;
+    }
+
+    const expiraTimestamp = new Date(expiraEm).getTime();
+
+    const atualizar = () => {
+      const diff = expiraTimestamp - Date.now();
+      setRestante(diff);
+      if (diff <= 0) {
+        logout();
+      }
+    };
+
+    atualizar();
+    const intervalo = setInterval(atualizar, 1000);
+    return () => clearInterval(intervalo);
+  }, [expiraEm, logout]);
+
+  if (restante === null) return null;
+
+  const critico = restante <= 5 * 60 * 1000; // últimos 5 minutos
+
+  return (
+    <Typography
+      variant="caption"
+      sx={{
+        color: critico ? "#fca5a5" : "rgba(255,255,255,0.7)",
+        display: "block",
+        textAlign: compacto ? "left" : "center",
+      }}
+    >
+      {compacto ? formatarRestante(restante) : `Sessão expira em ${formatarRestante(restante)}`}
+    </Typography>
+  );
+};
+
+export default SessaoCountdown;

--- a/src/Igreja/Components/EnderecoForm.jsx
+++ b/src/Igreja/Components/EnderecoForm.jsx
@@ -30,6 +30,7 @@ const EnderecoForm = ({
                       }) => {
     const [enderecosMap, setEnderecosMap] = useState({});
     const [enderecosLoading, setEnderecosLoading] = useState(false);
+    const [apoio, setApoio] = useState("");
 
     const handleChange = (field, value) => {
         setEndereco((prev) => ({
@@ -297,6 +298,19 @@ const EnderecoForm = ({
                         fullWidth
                         type="number"
                         inputProps={{ step: "0.000001" }}
+                    />
+                </Grid>
+
+                <Grid size={{ xs: 12 }}>
+                    <TextField
+                        label="Apoio"
+                        value={apoio}
+                        onChange={(e) => setApoio(e.target.value)}
+                        fullWidth
+                        multiline
+                        rows={3}
+                        placeholder="Anotações temporárias de apoio (não salvo)..."
+                        helperText="Este campo não é salvo."
                     />
                 </Grid>
             </Grid>

--- a/src/Igreja/Components/MissaForm.jsx
+++ b/src/Igreja/Components/MissaForm.jsx
@@ -23,7 +23,7 @@ import {
     Divider,
     Tooltip,
 } from "@mui/material";
-import { Delete, Add, ExpandMore, ExpandLess } from "@mui/icons-material";
+import { Delete, Add, ExpandMore, ExpandLess, DeleteSweep } from "@mui/icons-material";
 import { diasDaSemana, formatarHorario, apenasNumeros } from "../../utils";
 import SectionCard from "./SectionCard";
 
@@ -38,6 +38,9 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
     const [multiHorario, setMultiHorario] = useState("");
     const [multiHorarios, setMultiHorarios] = useState([]);
     const multiHorarioRef = useRef(null);
+
+    // Seleção múltipla para deletar em lote
+    const [selecionadas, setSelecionadas] = useState([]);
 
     const handleChange = (field, value) => {
         setNovaMissa((prev) => ({ ...prev, [field]: value }));
@@ -79,6 +82,27 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
 
     const handleDeleteMissa = (indexToDelete) => {
         setMissas((prev) => prev.filter((_, index) => index !== indexToDelete));
+        setSelecionadas((prev) => prev.filter((i) => i !== indexToDelete));
+    };
+
+    const handleDeleteTodas = () => {
+        setMissas([]);
+        setSelecionadas([]);
+    };
+
+    const handleToggleSelecionada = (index) => {
+        setSelecionadas((prev) =>
+            prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
+        );
+    };
+
+    const handleToggleSelecionarTodas = () => {
+        setSelecionadas((prev) => (prev.length === missas.length ? [] : missas.map((_, i) => i)));
+    };
+
+    const handleDeleteSelecionadas = () => {
+        setMissas((prev) => prev.filter((_, index) => !selecionadas.includes(index)));
+        setSelecionadas([]);
     };
 
     const handleAdicionarMultiHorario = () => {
@@ -271,32 +295,95 @@ const MissaForm = ({ missas = [], setMissas, onError }) => {
                 />
 
                 {missas.length > 0 && (
-                    <TableContainer component={Paper} sx={{ mt: 1, borderRadius: 2 }}>
-                        <Table size="small">
-                            <TableHead>
-                                <TableRow sx={{ backgroundColor: "grey.100" }}>
-                                    <TableCell><strong>Horário</strong></TableCell>
-                                    <TableCell><strong>Dia</strong></TableCell>
-                                    <TableCell><strong>Observação</strong></TableCell>
-                                    <TableCell align="center"><strong>Ações</strong></TableCell>
-                                </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {missas.map((missa, index) => (
-                                    <TableRow key={`${missa.horario}-${missa.diaSemana}-${index}`} hover>
-                                        <TableCell>{formatarHorario(missa.horario)}</TableCell>
-                                        <TableCell>{getDiaLabel(missa.diaSemana)}</TableCell>
-                                        <TableCell>{missa.observacao || "Sem observação"}</TableCell>
-                                        <TableCell align="center">
-                                            <IconButton color="error" onClick={() => handleDeleteMissa(index)}>
-                                                <Delete />
-                                            </IconButton>
+                    <>
+                        <Box display="flex" alignItems="center" justifyContent="space-between" sx={{ mt: 1 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                {selecionadas.length > 0
+                                    ? `${selecionadas.length} selecionada(s)`
+                                    : `${missas.length} missa(s) cadastrada(s)`}
+                            </Typography>
+                            <Stack direction="row" spacing={1}>
+                                {selecionadas.length > 0 && (
+                                    <Button
+                                        size="small"
+                                        color="error"
+                                        variant="outlined"
+                                        startIcon={<Delete />}
+                                        onClick={handleDeleteSelecionadas}
+                                    >
+                                        Deletar selecionadas ({selecionadas.length})
+                                    </Button>
+                                )}
+                                <Button
+                                    size="small"
+                                    color="error"
+                                    startIcon={<DeleteSweep />}
+                                    onClick={handleDeleteTodas}
+                                >
+                                    Deletar todas
+                                </Button>
+                            </Stack>
+                        </Box>
+
+                        <TableContainer component={Paper} sx={{ mt: 1, borderRadius: 2 }}>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow sx={{ backgroundColor: "grey.100" }}>
+                                        <TableCell padding="checkbox">
+                                            <Checkbox
+                                                size="small"
+                                                indeterminate={selecionadas.length > 0 && selecionadas.length < missas.length}
+                                                checked={missas.length > 0 && selecionadas.length === missas.length}
+                                                onChange={handleToggleSelecionarTodas}
+                                            />
                                         </TableCell>
+                                        <TableCell><strong>Horário</strong></TableCell>
+                                        <TableCell><strong>Observação</strong></TableCell>
+                                        <TableCell align="center"><strong>Ações</strong></TableCell>
                                     </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
+                                </TableHead>
+                                <TableBody>
+                                    {diasDaSemana.map((dia) => {
+                                        const missasDoDia = missas
+                                            .map((missa, index) => ({ missa, index }))
+                                            .filter(({ missa }) => Number(missa.diaSemana) === dia.value);
+
+                                        if (missasDoDia.length === 0) return null;
+
+                                        return (
+                                            <React.Fragment key={`grupo-${dia.value}`}>
+                                                <TableRow>
+                                                    <TableCell colSpan={4} sx={{ backgroundColor: "grey.50", py: 0.5 }}>
+                                                        <Typography variant="caption" fontWeight={700}>
+                                                            {dia.label}
+                                                        </Typography>
+                                                    </TableCell>
+                                                </TableRow>
+                                                {missasDoDia.map(({ missa, index }) => (
+                                                    <TableRow key={`${missa.horario}-${missa.diaSemana}-${index}`} hover selected={selecionadas.includes(index)}>
+                                                        <TableCell padding="checkbox">
+                                                            <Checkbox
+                                                                size="small"
+                                                                checked={selecionadas.includes(index)}
+                                                                onChange={() => handleToggleSelecionada(index)}
+                                                            />
+                                                        </TableCell>
+                                                        <TableCell>{formatarHorario(missa.horario)}</TableCell>
+                                                        <TableCell>{missa.observacao || "Sem observação"}</TableCell>
+                                                        <TableCell align="center">
+                                                            <IconButton color="error" onClick={() => handleDeleteMissa(index)}>
+                                                                <Delete />
+                                                            </IconButton>
+                                                        </TableCell>
+                                                    </TableRow>
+                                                ))}
+                                            </React.Fragment>
+                                        );
+                                    })}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    </>
                 )}
             </Box>
         </SectionCard>

--- a/src/Igreja/IgrejaDetalhesModal.jsx
+++ b/src/Igreja/IgrejaDetalhesModal.jsx
@@ -72,7 +72,7 @@ const IgrejaDetalheModal = ({ open, handleClose, igrejaId }) => {
           top: "50%",
           left: "50%",
           transform: "translate(-50%, -50%)",
-          width: 500,
+          width: "min(500px, 92vw)",
           maxHeight: "85vh",
           overflowY: "auto",
           bgcolor: "background.paper",

--- a/src/ReportarProblema/ReportarProblema.jsx
+++ b/src/ReportarProblema/ReportarProblema.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Link,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import CancelIcon from "@mui/icons-material/Cancel";
+import EditIcon from "@mui/icons-material/Edit";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import { useNavigate } from "react-router-dom";
+import Menu from "../Components/Menu";
+import Pagination from "../Components/Paginacao";
+import api from "../services/apiService";
+import IgrejaDetalheModal from "../Igreja/IgrejaDetalhesModal";
+import ReportarProblemaModal from "../Igreja/Components/ReportarProblemaModal";
+import { buscarIgrejaCompletaPorId, normalizarIgrejaParaEdicao } from "../services/igrejaHelpers";
+
+const formatarData = (valor) => (valor ? new Date(valor).toLocaleString("pt-BR") : "-");
+
+const FILTROS_RESOLVIDO = [
+  { valor: "false", label: "Pendentes" },
+  { valor: "true", label: "Resolvidos" },
+  { valor: "", label: "Todos" },
+];
+
+const ReportarProblemaPage = () => {
+  const navigate = useNavigate();
+  const [filtroResolvido, setFiltroResolvido] = useState("false");
+  const [itens, setItens] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [paginacao, setPaginacao] = useState({
+    pageIndex: 1, pageSize: 20, totalPages: 1, hasPreviousPage: false, hasNextPage: false, totalItems: 0,
+  });
+
+  const [detalheIgrejaId, setDetalheIgrejaId] = useState(null);
+  const [problemaAberto, setProblemaAberto] = useState(null);
+
+  const buscar = (pageIndex = 1) => {
+    setIsLoading(true);
+    const params = { "Paginacao.PageIndex": pageIndex, "Paginacao.PageSize": paginacao.pageSize };
+    if (filtroResolvido !== "") params.Resolvido = filtroResolvido;
+
+    api.get("/api/v1/Admin/igreja/reportar-problema", { params })
+      .then((response) => {
+        const data = response.data?.data || response.data;
+        setItens(data?.items || []);
+        setPaginacao((prev) => ({
+          ...prev,
+          pageIndex,
+          totalPages: data?.totalPages ?? 1,
+          hasPreviousPage: data?.hasPrevieusPage ?? false,
+          hasNextPage: data?.hasNextPage ?? false,
+          totalItems: data?.totalItems ?? 0,
+        }));
+      })
+      .catch(() => setItens([]))
+      .finally(() => setIsLoading(false));
+  };
+
+  useEffect(() => { buscar(1); }, [filtroResolvido]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const resolvido = (item) => !!item.acaoRealizada;
+
+  const editarIgreja = async (igrejaId) => {
+    try {
+      const igrejaCompleta = await buscarIgrejaCompletaPorId(igrejaId);
+      navigate("/igrejaEditar", { state: { row: normalizarIgrejaParaEdicao(igrejaCompleta) } });
+    } catch {
+      // silencioso — usuário pode tentar de novo ou usar "Ver detalhes" -> Editar
+    }
+  };
+
+  return (
+    <Menu>
+      <Stack spacing={2}>
+        <Paper sx={{ p: 2, borderRadius: 2 }}>
+          <TextField
+            select
+            size="small"
+            label="Status"
+            value={filtroResolvido}
+            onChange={(e) => setFiltroResolvido(e.target.value)}
+            sx={{ minWidth: 200 }}
+            SelectProps={{ native: true }}
+          >
+            {FILTROS_RESOLVIDO.map((f) => (
+              <option key={f.label} value={f.valor}>{f.label}</option>
+            ))}
+          </TextField>
+        </Paper>
+
+        <TableContainer component={Paper} sx={{ p: 2, borderRadius: 2 }}>
+          <Typography variant="h6" sx={{ mb: 2 }}>Problemas Reportados</Typography>
+
+          {isLoading ? (
+            <Box display="flex" justifyContent="center" py={6}><CircularProgress /></Box>
+          ) : (
+            <>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Igreja</TableCell>
+                    <TableCell>Cidade/UF</TableCell>
+                    <TableCell>Solicitante</TableCell>
+                    <TableCell>Descrição</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell>Data</TableCell>
+                    <TableCell align="center">Ações</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {itens.length === 0 ? (
+                    <TableRow><TableCell colSpan={7} align="center">Nenhum problema reportado encontrado.</TableCell></TableRow>
+                  ) : (
+                    itens.map((item) => (
+                      <TableRow key={item.id} hover>
+                        <TableCell>
+                          <Link component="button" underline="hover" onClick={() => setDetalheIgrejaId(item.igrejaId)}>
+                            {item.nomeIgreja}
+                          </Link>
+                        </TableCell>
+                        <TableCell>{[item.cidade, item.uf].filter(Boolean).join(" / ") || "-"}</TableCell>
+                        <TableCell>
+                          {item.nome}
+                          <Typography variant="caption" color="text.secondary" display="block">
+                            {item.email}
+                          </Typography>
+                        </TableCell>
+                        <TableCell sx={{ maxWidth: 260 }}>
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                            title={item.descricao}
+                          >
+                            {item.descricao}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            icon={resolvido(item) ? <CheckCircleIcon fontSize="small" /> : <CancelIcon fontSize="small" />}
+                            label={resolvido(item) ? "Resolvido" : "Pendente"}
+                            color={resolvido(item) ? "success" : "warning"}
+                            size="small"
+                            variant="outlined"
+                          />
+                        </TableCell>
+                        <TableCell>{formatarData(item.dataCriacao)}</TableCell>
+                        <TableCell align="center">
+                          <Stack direction="row" spacing={0.5} justifyContent="center">
+                            <Tooltip title="Ver detalhes da igreja">
+                              <IconButton size="small" onClick={() => setDetalheIgrejaId(item.igrejaId)}>
+                                <VisibilityIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title="Editar igreja">
+                              <IconButton size="small" onClick={() => editarIgreja(item.igrejaId)}>
+                                <EditIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            {!resolvido(item) && (
+                              <Button size="small" variant="contained" onClick={() => setProblemaAberto(item)}>
+                                Resolver
+                              </Button>
+                            )}
+                          </Stack>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+                <TableFooter>
+                  <TableRow>
+                    <TableCell colSpan={7} align="right">Total: {paginacao.totalItems}</TableCell>
+                  </TableRow>
+                </TableFooter>
+              </Table>
+
+              <Pagination
+                pageIndex={paginacao.pageIndex}
+                totalPages={paginacao.totalPages}
+                hasPreviousPage={paginacao.hasPreviousPage}
+                hasNextPage={paginacao.hasNextPage}
+                onPageChange={buscar}
+              />
+            </>
+          )}
+        </TableContainer>
+      </Stack>
+
+      <IgrejaDetalheModal
+        open={!!detalheIgrejaId}
+        handleClose={() => setDetalheIgrejaId(null)}
+        igrejaId={detalheIgrejaId}
+      />
+
+      {problemaAberto && (
+        <ReportarProblemaModal
+          open={!!problemaAberto}
+          onClose={() => setProblemaAberto(null)}
+          problemaId={problemaAberto.id}
+          nome={problemaAberto.nome}
+          email={problemaAberto.email}
+          descricao={problemaAberto.descricao}
+          onSuccess={() => { setProblemaAberto(null); buscar(paginacao.pageIndex); }}
+        />
+      )}
+    </Menu>
+  );
+};
+
+export default ReportarProblemaPage;


### PR DESCRIPTION
## Resumo
Cinco itens (dos concretos pedidos):

1. **Problemas Reportados**: nova tela de listagem (menu novo), já que hoje só existia inline na edição de cada igreja. Link e ícone abrem o modal de detalhes da igreja (`IgrejaDetalhesModal`, já componentizado) ou vão direto para a edição; botão "Resolver" reaproveita o `ReportarProblemaModal` existente.
2. **Endereço — Apoio**: textarea de anotação temporária (mesmo padrão já usado no `MissaForm`), não persistida.
3. **Missas — Deletar todas**: botão que limpa a lista inteira.
4. **Missas — seleção múltipla**: checkboxes por linha + "selecionar todas" + "Deletar selecionadas".
5. **Missas — agrupamento por dia**: a tabela agora agrupa as missas por dia da semana com um cabeçalho de grupo, em vez de lista plana.
6. **Contador de sessão**: novo componente `SessaoCountdown` na barra lateral, calculado a partir de `acessToken.expira` (já retornado pelo backend no login, só não era usado). Desloga automaticamente ao chegar a zero.

## Dependência
Item 1 requer o [PR do backend](https://github.com/FabioVeiga/buscamissa-backend/pull/104) (endpoint de listagem de problemas reportados).

## Pendente (não implementado neste PR)
Mobile e "melhorar todo o visual" ficaram de fora — são temas grandes que precisam de escopo/prioridade antes de implementar.

## Test plan
- [x] Lint sem erros novos
- [x] Build de produção sem erros
- [ ] Teste manual de cada item, com o backend do PR companheiro rodando