### PR TITLE
feat: responsividade mobile — cards e filtros empilháveis

### DIFF
--- a/src/Aprovacoes/Aprovacoes.jsx
+++ b/src/Aprovacoes/Aprovacoes.jsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 import {
   Box,
   Button,
+  Card,
+  CardContent,
   Chip,
   CircularProgress,
   Dialog,
@@ -21,6 +23,8 @@ import {
   TableRow,
   TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
@@ -103,6 +107,8 @@ const BlocoDados = ({ titulo, dados }) => (
 
 const Aprovacoes = () => {
   const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [statusFiltro, setStatusFiltro] = useState(null);
   const [itens, setItens] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -251,6 +257,27 @@ const Aprovacoes = () => {
     }
   };
 
+  const renderAcoes = (item) => (
+    <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap justifyContent={isMobile ? "flex-start" : "center"}>
+      <Button size="small" startIcon={<VisibilityIcon />} onClick={() => abrirDetalhe(item)}>
+        Ver
+      </Button>
+      {item.status !== STATUS.FINALIZADO && item.status !== STATUS.REJEITADO && (
+        <>
+          <Button size="small" color="success" startIcon={<CheckCircleIcon />} onClick={() => aprovar(item.controleId)}>
+            Aprovar
+          </Button>
+          <Button size="small" color="secondary" startIcon={<EditIcon />} onClick={() => ajustar(item)}>
+            Ajustar
+          </Button>
+          <Button size="small" color="error" startIcon={<CancelIcon />} onClick={() => rejeitar(item.controleId)}>
+            Rejeitar
+          </Button>
+        </>
+      )}
+    </Stack>
+  );
+
   return (
     <Menu>
       <Stack spacing={2}>
@@ -272,90 +299,108 @@ const Aprovacoes = () => {
           <ErrorSpan errorMessage={message.mensagem} severity={message.severity} />
         )}
 
-        <TableContainer component={Paper} sx={{ p: 2, borderRadius: 2 }}>
-          <Typography variant="h6" sx={{ mb: 2 }}>Aprovações Pendentes</Typography>
-
-          {isLoading ? (
+        {isLoading ? (
+          <Paper sx={{ p: 2, borderRadius: 2 }}>
             <Box display="flex" justifyContent="center" py={6}><CircularProgress /></Box>
-          ) : (
-            <>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Igreja</TableCell>
-                    <TableCell>Cidade/UF</TableCell>
-                    <TableCell>Tipo</TableCell>
-                    <TableCell>Usuário</TableCell>
-                    <TableCell>Status</TableCell>
-                    <TableCell>Data</TableCell>
-                    <TableCell align="center">Ações</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {itens.length === 0 ? (
-                    <TableRow><TableCell colSpan={7} align="center">Nenhum item encontrado.</TableCell></TableRow>
-                  ) : (
-                    itens.map((item) => (
-                      <TableRow key={item.controleId} hover>
-                        <TableCell>{item.nomeIgreja}</TableCell>
-                        <TableCell>{[item.cidade, item.uf].filter(Boolean).join(" / ") || "-"}</TableCell>
-                        <TableCell>{item.tipo === "Criacao" ? "Criação" : "Alteração"}</TableCell>
-                        <TableCell>
-                          {item.usuarioNome ? (
-                            <>
-                              {item.usuarioNome}
-                              {item.usuarioEmail && (
-                                <Typography variant="caption" color="text.secondary" display="block">
-                                  {item.usuarioEmail}
-                                </Typography>
-                              )}
-                            </>
-                          ) : (
-                            <Typography variant="body2" color="text.secondary">Ainda não atribuído</Typography>
-                          )}
-                        </TableCell>
-                        <TableCell>{STATUS_LABELS[item.status] || item.status}</TableCell>
-                        <TableCell>{formatarData(item.dataCriacao)}</TableCell>
-                        <TableCell align="center">
-                          <Stack direction="row" spacing={0.5} justifyContent="center">
-                            <Button size="small" startIcon={<VisibilityIcon />} onClick={() => abrirDetalhe(item)}>
-                              Ver
-                            </Button>
-                            {item.status !== STATUS.FINALIZADO && item.status !== STATUS.REJEITADO && (
-                              <>
-                                <Button size="small" color="success" startIcon={<CheckCircleIcon />} onClick={() => aprovar(item.controleId)}>
-                                  Aprovar
-                                </Button>
-                                <Button size="small" color="secondary" startIcon={<EditIcon />} onClick={() => ajustar(item)}>
-                                  Ajustar
-                                </Button>
-                                <Button size="small" color="error" startIcon={<CancelIcon />} onClick={() => rejeitar(item.controleId)}>
-                                  Rejeitar
-                                </Button>
-                              </>
+          </Paper>
+        ) : isMobile ? (
+          <Paper sx={{ p: 2, borderRadius: 2 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>Aprovações Pendentes</Typography>
+            <Stack spacing={1.5}>
+              {itens.length === 0 ? (
+                <Typography color="text.secondary" textAlign="center" py={4}>Nenhum item encontrado.</Typography>
+              ) : (
+                itens.map((item) => (
+                  <Card key={item.controleId} variant="outlined">
+                    <CardContent sx={{ pb: 1, "&:last-child": { pb: 1 } }}>
+                      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                        <Box>
+                          <Typography sx={{ fontWeight: 600 }}>{item.nomeIgreja}</Typography>
+                          <Typography variant="body2" color="text.secondary">
+                            {[item.cidade, item.uf].filter(Boolean).join(" / ") || "-"} · {item.tipo === "Criacao" ? "Criação" : "Alteração"}
+                          </Typography>
+                        </Box>
+                        <Chip label={STATUS_LABELS[item.status] || item.status} size="small" />
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                        {item.usuarioNome || "Ainda não atribuído"} · {formatarData(item.dataCriacao)}
+                      </Typography>
+                      <Box sx={{ mt: 1 }}>{renderAcoes(item)}</Box>
+                    </CardContent>
+                  </Card>
+                ))
+              )}
+            </Stack>
+            <Pagination
+              pageIndex={paginacao.pageIndex}
+              totalPages={paginacao.totalPages}
+              hasPreviousPage={paginacao.hasPreviousPage}
+              hasNextPage={paginacao.hasNextPage}
+              onPageChange={buscar}
+            />
+          </Paper>
+        ) : (
+          <TableContainer component={Paper} sx={{ p: 2, borderRadius: 2 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>Aprovações Pendentes</Typography>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Igreja</TableCell>
+                  <TableCell>Cidade/UF</TableCell>
+                  <TableCell>Tipo</TableCell>
+                  <TableCell>Usuário</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Data</TableCell>
+                  <TableCell align="center">Ações</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {itens.length === 0 ? (
+                  <TableRow><TableCell colSpan={7} align="center">Nenhum item encontrado.</TableCell></TableRow>
+                ) : (
+                  itens.map((item) => (
+                    <TableRow key={item.controleId} hover>
+                      <TableCell>{item.nomeIgreja}</TableCell>
+                      <TableCell>{[item.cidade, item.uf].filter(Boolean).join(" / ") || "-"}</TableCell>
+                      <TableCell>{item.tipo === "Criacao" ? "Criação" : "Alteração"}</TableCell>
+                      <TableCell>
+                        {item.usuarioNome ? (
+                          <>
+                            {item.usuarioNome}
+                            {item.usuarioEmail && (
+                              <Typography variant="caption" color="text.secondary" display="block">
+                                {item.usuarioEmail}
+                              </Typography>
                             )}
-                          </Stack>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
+                          </>
+                        ) : (
+                          <Typography variant="body2" color="text.secondary">Ainda não atribuído</Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>{STATUS_LABELS[item.status] || item.status}</TableCell>
+                      <TableCell>{formatarData(item.dataCriacao)}</TableCell>
+                      <TableCell align="center">
+                        {renderAcoes(item)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
 
-              <Pagination
-                pageIndex={paginacao.pageIndex}
-                totalPages={paginacao.totalPages}
-                hasPreviousPage={paginacao.hasPreviousPage}
-                hasNextPage={paginacao.hasNextPage}
-                onPageChange={buscar}
-              />
-            </>
-          )}
-        </TableContainer>
+            <Pagination
+              pageIndex={paginacao.pageIndex}
+              totalPages={paginacao.totalPages}
+              hasPreviousPage={paginacao.hasPreviousPage}
+              hasNextPage={paginacao.hasNextPage}
+              onPageChange={buscar}
+            />
+          </TableContainer>
+        )}
       </Stack>
 
       {/* Modal de detalhe — comparativo antes/depois */}
-      <Dialog open={detalheAberto} onClose={fecharDetalhe} maxWidth="md" fullWidth>
+      <Dialog open={detalheAberto} onClose={fecharDetalhe} maxWidth="md" fullWidth fullScreen={isMobile}>
         <DialogTitle>Detalhe da solicitação</DialogTitle>
         <DialogContent>
           {detalheLoading || !detalhe ? (
@@ -399,7 +444,7 @@ const Aprovacoes = () => {
       </Dialog>
 
       {/* Modal de ajuste (só alteração) */}
-      <Dialog open={ajustarAberto} onClose={fecharAjustar} maxWidth="md" fullWidth>
+      <Dialog open={ajustarAberto} onClose={fecharAjustar} maxWidth="md" fullWidth fullScreen={isMobile}>
         <DialogTitle>Ajustar alteração antes de concluir</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>

--- a/src/EmailEvento/EmailEvento.jsx
+++ b/src/EmailEvento/EmailEvento.jsx
@@ -276,7 +276,7 @@ const EmailEventoPage = () => {
               value={filtrosTexto.nome}
               onChange={(e) => setFiltrosTexto((p) => ({ ...p, nome: e.target.value }))}
               onKeyDown={(e) => e.key === "Enter" && handlePesquisar()}
-              sx={{ minWidth: 200 }}
+              sx={{ width: { xs: "100%", sm: 200 } }}
             />
             <TextField
               label="Cidade"
@@ -284,7 +284,7 @@ const EmailEventoPage = () => {
               value={filtrosTexto.cidade}
               onChange={(e) => setFiltrosTexto((p) => ({ ...p, cidade: e.target.value }))}
               onKeyDown={(e) => e.key === "Enter" && handlePesquisar()}
-              sx={{ minWidth: 160 }}
+              sx={{ width: { xs: "100%", sm: 160 } }}
             />
             <TextField
               label="UF"
@@ -292,12 +292,12 @@ const EmailEventoPage = () => {
               value={filtrosTexto.uf}
               onChange={(e) => setFiltrosTexto((p) => ({ ...p, uf: e.target.value.toUpperCase().slice(0, 2) }))}
               onKeyDown={(e) => e.key === "Enter" && handlePesquisar()}
-              sx={{ width: 90 }}
+              sx={{ width: { xs: "100%", sm: 90 } }}
             />
-            <Button variant="contained" size="small" onClick={handlePesquisar}>
+            <Button variant="contained" size="small" onClick={handlePesquisar} sx={{ width: { xs: "100%", sm: "auto" } }}>
               Pesquisar
             </Button>
-            <Button variant="outlined" size="small" onClick={handleLimpar}>
+            <Button variant="outlined" size="small" onClick={handleLimpar} sx={{ width: { xs: "100%", sm: "auto" } }}>
               Limpar
             </Button>
             <Button
@@ -306,7 +306,7 @@ const EmailEventoPage = () => {
               size="small"
               startIcon={<PhoneCallbackIcon />}
               onClick={abrirModalRegistroManual}
-              sx={{ ml: "auto" }}
+              sx={{ width: { xs: "100%", sm: "auto" }, ml: { sm: "auto" } }}
             >
               Registrar contato
             </Button>

--- a/src/Igreja/Igreja.jsx
+++ b/src/Igreja/Igreja.jsx
@@ -15,6 +15,10 @@ import {
   Box,
   Chip,
   Typography,
+  Card,
+  CardContent,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import Menu from "../Components/Menu";
 import Pagination from "../Components/Paginacao";
@@ -36,6 +40,8 @@ import { useEffect } from "react";
 
 
 const IgrejaPage = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [igrejas, setIgrejas] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [paginacao, setPaginacao] = useState({
@@ -255,6 +261,52 @@ const IgrejaPage = () => {
     }));
   };
 
+  // Compartilhado entre a linha da tabela (desktop) e o card (mobile).
+  const renderAcoes = (row) => (
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+      <Tooltip title="Detalhes">
+        <IconButton color="primary" onClick={() => handleOpen(row)}>
+          <OpenInNewIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Editar">
+        <IconButton color="primary" onClick={() => navigate("/IgrejaEditar", { state: { row } })}>
+          <EditIcon />
+        </IconButton>
+      </Tooltip>
+      {row.reportarProblema && (
+        <>
+          <Tooltip title="Problema reportado">
+            <IconButton color="warning" onClick={handleOpenModal}>
+              <AnnouncementIcon />
+            </IconButton>
+          </Tooltip>
+          <ReportarProblemaModal
+            open={problemaModalOpen}
+            onClose={handleCloseModal}
+            problemaId={row.reportarProblema.id}
+            nome={row.reportarProblema.nome}
+            email={row.reportarProblema.email}
+            descricao={row.reportarProblema.descricao}
+            onSuccess={handleSuccess}
+          />
+        </>
+      )}
+      {!row.ativo && (
+        <Tooltip title="Ativar">
+          <IconButton color="primary" onClick={() => handleOpenConfirmModal(row.id)}>
+            <HideSourceIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+      <Tooltip title="Deletar">
+        <IconButton color="error" onClick={() => handleOpenDeleteModal(row.id)}>
+          <DeleteIcon />
+        </IconButton>
+      </Tooltip>
+    </Stack>
+  );
+
   return (
     <>
       <IgrejaDetalheModal
@@ -298,6 +350,65 @@ const IgrejaPage = () => {
               <Typography variant="h6" mt={2}>
                 Carregando...
               </Typography>
+            </Box>
+          ) : isMobile ? (
+            <Box sx={{ flex: 1, overflow: "auto" }}>
+              <Stack spacing={1.5}>
+                {igrejas.items && igrejas.items.length > 0 ? (
+                  igrejas.items.map((row) => (
+                    <Card key={row.id} variant="outlined">
+                      <CardContent sx={{ pb: 1, "&:last-child": { pb: 1 } }}>
+                        <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                          <Box>
+                            <Typography sx={{ fontWeight: 600 }}>{row.nome}</Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              {row.endereco?.localidade} / {row.endereco?.uf}
+                            </Typography>
+                          </Box>
+                          <Chip
+                            label={row.ativo ? "Ativo" : "Inativo"}
+                            size="small"
+                            color={row.ativo ? "success" : "default"}
+                          />
+                        </Stack>
+                        {row.endereco?.cep && (
+                          <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                            CEP: {row.endereco.cep}
+                          </Typography>
+                        )}
+                        {row.slug && (
+                          <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.5 }}>
+                            <Link
+                              href={buildParoquiaUrl(row)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              underline="hover"
+                              sx={{
+                                maxWidth: "80%",
+                                display: "inline-block",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                                fontSize: "0.8125rem",
+                              }}
+                            >
+                              {shortParoquiaText(row)}
+                            </Link>
+                            <IconButton size="small" onClick={() => handleCopyUrl(buildParoquiaUrl(row))}>
+                              <ContentCopyIcon fontSize="small" />
+                            </IconButton>
+                          </Stack>
+                        )}
+                        <Box sx={{ mt: 1 }}>{renderAcoes(row)}</Box>
+                      </CardContent>
+                    </Card>
+                  ))
+                ) : (
+                  <Typography color="text.secondary" textAlign="center" py={4}>
+                    Não há dados disponíveis.
+                  </Typography>
+                )}
+              </Stack>
             </Box>
           ) : (
             <Box sx={{ flex: 1, overflow: "auto" }}>
@@ -392,73 +503,7 @@ const IgrejaPage = () => {
                         />
                       </TableCell>
                       <TableCell>
-                        <Stack direction="row" spacing={1}>
-                          <Tooltip title="Detalhes">
-                            <IconButton
-                              color="primary"
-                              onClick={() => {
-                                handleOpen(row);
-                              }}
-                            >
-                              <OpenInNewIcon />
-                            </IconButton>
-                          </Tooltip>
-                          <Tooltip title="Editar">
-                            <IconButton
-                              color="primary"
-                              onClick={() =>
-                                navigate("/IgrejaEditar", { state: { row } })
-                              }
-                            >
-                              <EditIcon />
-                            </IconButton>
-                          </Tooltip>
-                          {row.reportarProblema && (
-                            <>
-                              <Tooltip title="Problema reportado">
-                                <IconButton
-                                  color="warning"
-                                  onClick={handleOpenModal}
-                                >
-                                  <AnnouncementIcon />
-                                </IconButton>
-                              </Tooltip>
-                              <ReportarProblemaModal
-                                open={problemaModalOpen}
-                                onClose={handleCloseModal}
-                                problemaId={row.reportarProblema.id}
-                                nome={row.reportarProblema.nome}
-                                email={row.reportarProblema.email}
-                                descricao={row.reportarProblema.descricao}
-                                onSuccess={handleSuccess} // Passa uma função, não uma chamada direta
-                              />
-                            </>
-                          )}
-                          {!row.ativo ? (
-                           <Tooltip title="Ativar">
-                           <IconButton
-                             color="primary"
-                             onClick={() => {
-                               handleOpenConfirmModal(row.id);
-                             }}
-                           >
-                             <HideSourceIcon />
-                           </IconButton>
-                         </Tooltip>
-                          ) : (
-                            ""
-                          )}
-
-                          <Tooltip title="Deletar">
-                            <IconButton
-                              color="error"
-                              onClick={() => handleOpenDeleteModal(row.id)}
-                            >
-                              <DeleteIcon />
-                            </IconButton>
-                          </Tooltip>
-                          
-                        </Stack>
+                        {renderAcoes(row)}
                       </TableCell>
                     </TableRow>
                   ))

--- a/src/Solicitacoes.jsx
+++ b/src/Solicitacoes.jsx
@@ -121,7 +121,14 @@ const SolicitacoesPage = () => {
     <Menu>
       <Box sx={{ p: { xs: 1, sm: 2 } }}>
         {/* Cabeçalho */}
-        <Box display="flex" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+        <Box
+          display="flex"
+          flexDirection={{ xs: "column", sm: "row" }}
+          justifyContent="space-between"
+          alignItems={{ xs: "stretch", sm: "center" }}
+          gap={2}
+          sx={{ mb: 3 }}
+        >
           <Box>
             <Typography variant="h5" fontWeight={700}>Solicitações</Typography>
             <Typography variant="body2" color="text.secondary">
@@ -129,13 +136,13 @@ const SolicitacoesPage = () => {
             </Typography>
           </Box>
 
-          <Box display="flex" gap={1} alignItems="center">
+          <Box display="flex" flexDirection={{ xs: "column", sm: "row" }} gap={1} alignItems={{ xs: "stretch", sm: "center" }}>
             <Select
               value={filtroResolvida}
               onChange={handleFiltroChange}
               displayEmpty
               size="small"
-              sx={{ minWidth: 180 }}
+              sx={{ minWidth: { xs: "100%", sm: 180 } }}
             >
               <MenuItem value="">Todas</MenuItem>
               <MenuItem value="true">Resolvidas</MenuItem>

--- a/src/Usuario.jsx
+++ b/src/Usuario.jsx
@@ -18,13 +18,15 @@ import {
   MenuItem,
   Link,
   IconButton,
+  Card,
+  CardContent,
 } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import Menu from "./Components/Menu";
 import api from "./services/apiService";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { CircularProgress, Box, Typography } from "@mui/material";
+import { CircularProgress, Box, Typography, useTheme, useMediaQuery } from "@mui/material";
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import ManageAccountsIcon from "@mui/icons-material/ManageAccounts";
 import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
@@ -64,6 +66,8 @@ const OPCOES_ORDENACAO = [
 
 const UsuarioPage = () => {
   const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [data, setData] = useState([]);
   const [paginacao, setPaginacao] = useState({});
   const [isLoading, setIsLoading] = useState(true);
@@ -294,6 +298,36 @@ const UsuarioPage = () => {
     setIgrejasUsuario([]);
   };
 
+  // Compartilhado entre a linha da tabela (desktop) e o card (mobile).
+  const renderAcoes = (row) => (
+    <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+      <Button variant="contained" color="primary" size="small" onClick={() => handleOpenDetailsModal(row)}>
+        Visualizar
+      </Button>
+      <Tooltip title={row.bloqueado ? "Clique para desbloquear o usuário" : "Clique para bloquear o usuário"}>
+        <Button
+          variant="contained"
+          color={row.bloqueado ? "error" : "success"}
+          size="small"
+          onClick={() => handleOpenModal(row)}
+        >
+          {row.bloqueado ? "Desbloquear" : "Bloquear"}
+        </Button>
+      </Tooltip>
+      <Tooltip title="Definir uma nova senha para o usuário">
+        <Button
+          variant="outlined"
+          color="warning"
+          size="small"
+          startIcon={<LockResetIcon />}
+          onClick={() => handleOpenSenhaModal(row)}
+        >
+          Resetar senha
+        </Button>
+      </Tooltip>
+    </Stack>
+  );
+
   const handleEditarIgreja = async (igrejaId) => {
     try {
       const igrejaCompleta = await buscarIgrejaCompletaPorId(igrejaId);
@@ -439,6 +473,38 @@ const UsuarioPage = () => {
               Carregando...
             </Typography>
           </Box>
+        ) : isMobile ? (
+          <Stack spacing={1.5}>
+            {data.items.map((row) => (
+              <Card key={row.id} variant="outlined">
+                <CardContent sx={{ pb: 1, "&:last-child": { pb: 1 } }}>
+                  <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                    <Box>
+                      <Typography sx={{ fontWeight: 600 }}>{row.nome}</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {perfil(row.perfil)}
+                      </Typography>
+                    </Box>
+                    <Typography variant="caption" color={row.bloqueado ? "error.main" : "text.secondary"}>
+                      {row.bloqueado ? "Bloqueado" : "Ativo"}
+                    </Typography>
+                  </Stack>
+                  <Tooltip title="Ver igrejas cadastradas por este usuário">
+                    <Button
+                      variant="text"
+                      size="small"
+                      startIcon={<ChurchIcon />}
+                      onClick={() => handleOpenIgrejasModal(row)}
+                      sx={{ mt: 0.5, pl: 0 }}
+                    >
+                      {row.totalIgrejas ?? 0} igreja(s)
+                    </Button>
+                  </Tooltip>
+                  <Box sx={{ mt: 1 }}>{renderAcoes(row)}</Box>
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
         ) : (
           <Table>
             <TableHead>
@@ -471,43 +537,7 @@ const UsuarioPage = () => {
                     </Tooltip>
                   </TableCell>
                   <TableCell>
-                    <Stack direction="row" spacing={1}>
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        size="small"
-                        onClick={() => handleOpenDetailsModal(row)}
-                      >
-                        Visualizar
-                      </Button>
-                      <Tooltip
-                        title={
-                          row.bloqueado
-                            ? "Clique para desbloquear o usuário"
-                            : "Clique para bloquear o usuário"
-                        }
-                      >
-                        <Button
-                          variant="contained"
-                          color={row.bloqueado ? "error" : "success"}
-                          size="small"
-                          onClick={() => handleOpenModal(row)}
-                        >
-                          {row.bloqueado ? "Desbloquear" : "Bloquear"}
-                        </Button>
-                      </Tooltip>
-                      <Tooltip title="Definir uma nova senha para o usuário">
-                        <Button
-                          variant="outlined"
-                          color="warning"
-                          size="small"
-                          startIcon={<LockResetIcon />}
-                          onClick={() => handleOpenSenhaModal(row)}
-                        >
-                          Resetar senha
-                        </Button>
-                      </Tooltip>
-                    </Stack>
+                    {renderAcoes(row)}
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## Resumo
Itens 2 e 3 do plano de mobile/visual:

**Item 2 — tabelas → cards no mobile** (telas mais usadas: Igreja, Usuário, Aprovações Pendentes):
- `useMediaQuery(theme.breakpoints.down("sm"))` alterna entre a tabela (desktop) e uma lista de `Card` empilhados (mobile), com os mesmos dados e as mesmas ações — extraídas para uma função `renderAcoes(row)` compartilhada, evitando duplicar lógica de clique.
- Modais de detalhe/ajuste em Aprovações agora usam `fullScreen` no mobile (eram `maxWidth="md"` fixo, ficavam apertados em telas pequenas).

**Item 3 — filtros com largura fixa** (EmailEvento, Solicitações): campos que usavam `minWidth` em pixels agora ocupam 100% da largura no mobile e empilham em coluna, em vez de espremer lado a lado.

## Verificação
- Lint e build de produção sem erros.
- Testado visualmente no preview em viewport mobile (375px): tela de Igrejas carrega e o formulário de filtro já renderiza empilhado e sem overflow horizontal. Não consegui popular dados reais da API (ambiente dev remoto, sem mock viável no sandbox), então a visualização dos cards com dados não foi verificada ao vivo — recomendo um teste manual rápido.

## Pendente
Item 4 (visual geral) segue em aberto — combinado que fica pra quando você apontar telas específicas.