### PR TITLE
fix: lista de igrejas some no mobile por causa de altura fixa

### DIFF
--- a/src/Igreja/Igreja.jsx
+++ b/src/Igreja/Igreja.jsx
@@ -329,7 +329,7 @@ const IgrejaPage = () => {
             borderRadius: 2,
             display: "flex",
             flexDirection: "column",
-            height: "calc(100vh - 160px)",
+            height: isMobile ? "auto" : "calc(100vh - 160px)",
           }}
         >
           <Typography variant="h5" sx={{ fontWeight: 600, mb: 2 }}>


### PR DESCRIPTION
## Contexto
Mesma situação do PR #92: o commit `59902d6` (correção da altura fixa do container que escondia a lista de igrejas no mobile) foi enviado à branch remota depois que o PR já havia sido mergeado no GitHub, então nunca chegou à `dev`/`master`.

## O que este PR faz
Reaplica (via cherry-pick) o commit perdido em `src/Igreja/Igreja.jsx`: o `TableContainer` tinha `height: calc(100vh - 160px)` fixo com `display:flex/flexDirection:column`, pensado pro layout de tabela do desktop. No mobile, o formulário de filtro empilhado ocupa muito mais altura, sobrando pouco/nenhum espaço pro `flex:1` da lista de cards — a lista ficava invisível/cortada. Agora a altura fixa só é aplicada fora do breakpoint mobile.

## Verificação
Build e lint passam sem novos erros.