### PR TITLE
feat: adiciona tela de mesclar métricas de igrejas duplicadas

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import EmailEventoPage from './EmailEvento/EmailEvento';
 import Indicadores from './Indicadores/Indicadores';
 import Aprovacoes from './Aprovacoes/Aprovacoes';
 import ReportarProblemaPage from './ReportarProblema/ReportarProblema';
+import MesclarMetricas from './Igreja/MesclarMetricas';
 import PrivateRoute from './PrivateRoute'
 
 
@@ -107,6 +108,14 @@ const App = () => {
                 element={
                     <PrivateRoute isAuthenticated={isAuthenticated} loading={loading}>
                         <ReportarProblemaPage />
+                    </PrivateRoute>
+                }
+            />
+            <Route
+                path="/mesclar-metricas"
+                element={
+                    <PrivateRoute isAuthenticated={isAuthenticated} loading={loading}>
+                        <MesclarMetricas />
                     </PrivateRoute>
                 }
             />

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -29,6 +29,7 @@ import EmailIcon from "@mui/icons-material/Email";
 import InsightsIcon from "@mui/icons-material/Insights";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
 import AnnouncementIcon from "@mui/icons-material/Announcement";
+import MergeTypeIcon from "@mui/icons-material/MergeType";
 import MenuIcon from "@mui/icons-material/Menu";
 import CloseIcon from "@mui/icons-material/Close";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -46,6 +47,7 @@ const navItems = [
   { path: "/igreja", label: "Igrejas", icon: ChurchIcon },
   { path: "/aprovacoes", label: "Aprovações Pendentes", icon: FactCheckIcon, badgeKey: "aprovacoes" },
   { path: "/reportar-problema", label: "Problemas Reportados", icon: AnnouncementIcon, badgeKey: "problemas" },
+  { path: "/mesclar-metricas", label: "Mesclar Métricas", icon: MergeTypeIcon },
   { path: "/solicitacoes", label: "Solicitações", icon: BuildIcon, badgeKey: "solicitacoes" },
   { path: "/contribuidores", label: "Contribuidores", icon: CurrencyExchangeIcon },
   { path: "/email-evento", label: "Divulgação", icon: EmailIcon },
@@ -58,6 +60,7 @@ const pageTitles = {
   "/igreja": "Igrejas",
   "/aprovacoes": "Aprovações Pendentes",
   "/reportar-problema": "Problemas Reportados",
+  "/mesclar-metricas": "Mesclar Métricas",
   "/solicitacoes": "Solicitações",
   "/contribuidores": "Contribuidores",
   "/igrejaNovo": "Nova Igreja",

--- a/src/Igreja/MesclarMetricas.jsx
+++ b/src/Igreja/MesclarMetricas.jsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Box, Button, CircularProgress, Paper, Stack, TextField, Typography } from "@mui/material";
+import Menu from "../Components/Menu";
+import api from "../services/apiService";
+import ErrorSpan from "../ErrorSpan";
+
+const MesclarMetricas = () => {
+  const [igrejaVencedoraId, setIgrejaVencedoraId] = useState("");
+  const [igrejaPerdedoraId, setIgrejaPerdedoraId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState({ mensagem: "", severity: "", show: false });
+
+  const handleMesclar = () => {
+    setLoading(true);
+    setMessage({ mensagem: "", severity: "", show: false });
+
+    api
+      .put("/api/v1/Admin/igreja/mesclar-metricas", {
+        igrejaVencedoraId: Number(igrejaVencedoraId),
+        igrejaPerdedoraId: Number(igrejaPerdedoraId),
+      })
+      .then(() => {
+        setMessage({ mensagem: "Métricas mescladas com sucesso!", severity: "success", show: true });
+        setIgrejaVencedoraId("");
+        setIgrejaPerdedoraId("");
+      })
+      .catch((error) => {
+        const mensagemAplicacao = error.response?.data?.data?.messagemAplicacao;
+        setMessage({
+          mensagem: mensagemAplicacao || "Erro ao mesclar métricas.",
+          severity: "error",
+          show: true,
+        });
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <Menu>
+      <Paper sx={{ p: 3, borderRadius: 2, maxWidth: 480 }}>
+        <Typography variant="h6" sx={{ mb: 1 }}>
+          Mesclar Métricas de Igrejas
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          Move as métricas (visualizações, cliques, favoritos etc.) da igreja perdedora
+          para a vencedora. Não altera nome, endereço, status ativo ou qualquer outro
+          dado das igrejas — só as métricas.
+        </Typography>
+
+        <Stack spacing={2}>
+          <TextField
+            label="ID da igreja vencedora (fica ativa)"
+            type="number"
+            value={igrejaVencedoraId}
+            onChange={(e) => setIgrejaVencedoraId(e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="ID da igreja perdedora (duplicata)"
+            type="number"
+            value={igrejaPerdedoraId}
+            onChange={(e) => setIgrejaPerdedoraId(e.target.value)}
+            fullWidth
+          />
+
+          <Button
+            variant="contained"
+            onClick={handleMesclar}
+            disabled={loading || !igrejaVencedoraId || !igrejaPerdedoraId}
+          >
+            {loading ? <CircularProgress size={20} /> : "Mesclar métricas"}
+          </Button>
+
+          {message.show && (
+            <Box>
+              <ErrorSpan errorMessage={message.mensagem} severity={message.severity} />
+            </Box>
+          )}
+        </Stack>
+      </Paper>
+    </Menu>
+  );
+};
+
+export default MesclarMetricas;

--- a/src/ReportarProblema/ReportarProblema.jsx
+++ b/src/ReportarProblema/ReportarProblema.jsx
@@ -77,10 +77,14 @@ const ReportarProblemaPage = () => {
 
   const resolvido = (item) => !!item.acaoRealizada;
 
-  const editarIgreja = async (igrejaId) => {
+  const editarIgreja = async (item) => {
     try {
-      const igrejaCompleta = await buscarIgrejaCompletaPorId(igrejaId);
-      navigate("/igrejaEditar", { state: { row: normalizarIgrejaParaEdicao(igrejaCompleta) } });
+      const igrejaCompleta = await buscarIgrejaCompletaPorId(item.igrejaId);
+      const row = normalizarIgrejaParaEdicao(igrejaCompleta);
+      // O endpoint de detalhe não traz o problema reportado (outra tabela);
+      // reaproveita os dados já carregados nesta listagem para o Alert em IgrejaAtualizar.jsx.
+      row.reportarProblema = { id: item.id, nome: item.nome, email: item.email, descricao: item.descricao };
+      navigate("/igrejaEditar", { state: { row } });
     } catch {
       // silencioso — usuário pode tentar de novo ou usar "Ver detalhes" -> Editar
     }
@@ -170,7 +174,7 @@ const ReportarProblemaPage = () => {
                               </IconButton>
                             </Tooltip>
                             <Tooltip title="Editar igreja">
-                              <IconButton size="small" onClick={() => editarIgreja(item.igrejaId)}>
+                              <IconButton size="small" onClick={() => editarIgreja(item)}>
                                 <EditIcon fontSize="small" />
                               </IconButton>
                             </Tooltip>


### PR DESCRIPTION
- Corrige alerta de problema reportado sumindo ao editar igreja pela tela de Problemas Reportados (reportarProblema era descartado na normalização antes de navegar)
- Nova tela /mesclar-metricas: move métricas (visualizações, cliques, favoritos etc.) da igreja duplicada para a que fica ativa, sem mexer em mais nenhum dado das igrejas