### PR TITLE
fix: sincroniza slug/cidadeSlug apos editar igreja para nao deixar li…

### DIFF
--- a/src/Igreja/IgrejaAtualizar.jsx
+++ b/src/Igreja/IgrejaAtualizar.jsx
@@ -597,7 +597,26 @@ const IgrejaAtualizar = () => {
 
     api
         .put("/api/v1/Admin/igreja/atualizar", req)
-        .then(() => {
+        .then((response) => {
+          // O backend recalcula o cidadeSlug (e, na primeira vez, slug/nomeUnico)
+          // a cada edição — sem sincronizar aqui, o link exibido para compartilhar
+          // ficava com o cidadeSlug antigo até a tela ser recarregada.
+          const igrejaAtualizada = response.data?.data?.response;
+          if (igrejaAtualizada) {
+            setFormData((prev) => ({
+              ...prev,
+              slug: igrejaAtualizada.slug ?? prev.slug,
+              nomeUnico: igrejaAtualizada.nomeUnico ?? prev.nomeUnico,
+              emailCriacaoEnviado: igrejaAtualizada.emailCriacaoEnviado ?? prev.emailCriacaoEnviado,
+            }));
+            if (igrejaAtualizada.endereco) {
+              setEndereco((prev) => ({
+                ...prev,
+                cidadeSlug: igrejaAtualizada.endereco.cidadeSlug,
+              }));
+            }
+          }
+
           setMessage({
             mensagem: "Igreja atualizada com sucesso!",
             severity: "success",


### PR DESCRIPTION
…nk de compartilhamento desatualizado

O backend recalcula o cidadeSlug (e slug/nomeUnico na primeira geracao) a cada edicao, mas o retorno do PUT era descartado pelo frontend - o link exibido para compartilhar so refletia o endereco novo apos um reload manual da pagina.