### PR TITLE
Badge de responsável, edição de responsáveis e links de redes sociais

### DIFF
--- a/src/Igreja/Components/RedeSocialForm.jsx
+++ b/src/Igreja/Components/RedeSocialForm.jsx
@@ -19,10 +19,12 @@ import {
   Snackbar,
   TextField,
   Typography,
+  Link,
 } from "@mui/material";
-import { Delete } from "@mui/icons-material";
+import { Delete, OpenInNew } from "@mui/icons-material";
 import api from "../../services/apiService";
 import { useRedesSociais } from "../../hooks/useRedesSociais";
+import { construirUrlRedeSocial } from "../../utils/redeSocialUrl";
 
 const RedeSocialForm = ({
                           redesSociaisExistentes,
@@ -231,12 +233,22 @@ const RedeSocialForm = ({
                         mb: 1,
                       }}
                   >
-                    <Typography>
-                      <strong>
-                        {obterNomePorId(rede.tipoRedeSocial)}:
-                      </strong>{" "}
-                      {rede.nomeDoPerfil}
-                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <Typography>
+                        <strong>
+                          {obterNomePorId(rede.tipoRedeSocial)}:
+                        </strong>
+                      </Typography>
+                      <Link
+                          href={construirUrlRedeSocial(rede.tipoRedeSocial, rede.nomeDoPerfil)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          sx={{ display: "flex", alignItems: "center", gap: 0.5 }}
+                      >
+                        {rede.nomeDoPerfil}
+                        <OpenInNew fontSize="small" />
+                      </Link>
+                    </Box>
 
                     <IconButton color="error" onClick={() => handleOpenModal(rede)}>
                       <Delete />

--- a/src/Igreja/Igreja.jsx
+++ b/src/Igreja/Igreja.jsx
@@ -466,7 +466,17 @@ const IgrejaPage = () => {
                         </Tooltip>
                       </TableCell>
                       <TableCell>
-                        <Typography sx={{ fontWeight: 600 }}>{row.nome}</Typography>
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <Typography sx={{ fontWeight: 600 }}>{row.nome}</Typography>
+                          {row.usuarioId && (
+                            <Chip
+                              label="Responsável"
+                              size="small"
+                              color="primary"
+                              variant="outlined"
+                            />
+                          )}
+                        </Stack>
                       </TableCell>
                       <TableCell>
                         {row.slug ? (

--- a/src/Igreja/IgrejaAtualizar.jsx
+++ b/src/Igreja/IgrejaAtualizar.jsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Chip,
 } from "@mui/material";
 import { ArrowBack } from "@mui/icons-material";
 import api from "../services/apiService";
@@ -772,16 +773,26 @@ const IgrejaAtualizar = () => {
             subtitle="Dados principais da igreja."
         >
           <Box display="flex" flexDirection="column" gap={2}>
-            <FormControlLabel
-                control={
-                  <Switch
-                      checked={formData?.ativo ?? false}
-                      onChange={(e) => handleChange("ativo", e.target.checked)}
-                      color="primary"
-                  />
-                }
-                label="Ativo"
-            />
+            <Stack direction="row" spacing={1} alignItems="center">
+              <FormControlLabel
+                  control={
+                    <Switch
+                        checked={formData?.ativo ?? false}
+                        onChange={(e) => handleChange("ativo", e.target.checked)}
+                        color="primary"
+                    />
+                  }
+                  label="Ativo"
+              />
+              {state?.row?.usuarioId && (
+                <Chip
+                    label="Tem responsável"
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                />
+              )}
+            </Stack>
 
             <TextField
                 label="Nome da Igreja"

--- a/src/Responsaveis.jsx
+++ b/src/Responsaveis.jsx
@@ -26,6 +26,7 @@ import {
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import BlockIcon from "@mui/icons-material/Block";
+import EditIcon from "@mui/icons-material/Edit";
 import api from "./services/apiService";
 
 const STATUS_META = {
@@ -46,6 +47,12 @@ const ResponsaveisPage = () => {
   const [motivo, setMotivo] = useState("");
   const [salvando, setSalvando] = useState(false);
   const [erroDialog, setErroDialog] = useState(null);
+
+  // Dialog de edição
+  const [dialogEdicao, setDialogEdicao] = useState(null);
+  const [formEdicao, setFormEdicao] = useState({ cargoInformado: "", observacaoSolicitacao: "" });
+  const [salvandoEdicao, setSalvandoEdicao] = useState(false);
+  const [erroEdicao, setErroEdicao] = useState(null);
 
   const carregar = useCallback(async () => {
     setIsLoading(true);
@@ -103,6 +110,36 @@ const ResponsaveisPage = () => {
     aprovar: "Aprovar responsável",
     rejeitar: "Rejeitar solicitação",
     revogar: "Revogar acesso",
+  };
+
+  const abrirEdicao = (registro) => {
+    setDialogEdicao(registro);
+    setFormEdicao({
+      cargoInformado: registro.cargoInformado || "",
+      observacaoSolicitacao: registro.observacaoSolicitacao || "",
+    });
+    setErroEdicao(null);
+  };
+
+  const salvarEdicao = async () => {
+    if (!dialogEdicao) return;
+
+    setSalvandoEdicao(true);
+    setErroEdicao(null);
+
+    try {
+      await api.put(`/api/v1/admin/responsaveis/${dialogEdicao.id}/editar`, formEdicao);
+      setDialogEdicao(null);
+      carregar();
+    } catch (error) {
+      const mensagem =
+        error.response?.data?.data ??
+        error.response?.data?.message ??
+        "Erro ao atualizar. Tente novamente.";
+      setErroEdicao(typeof mensagem === "string" ? mensagem : "Erro ao processar. Tente novamente.");
+    } finally {
+      setSalvandoEdicao(false);
+    }
   };
 
   return (
@@ -183,6 +220,16 @@ const ResponsaveisPage = () => {
                       <TableCell align="center" sx={{ whiteSpace: "nowrap" }}>
                         {r.status === "PendenteVerificacao" && (
                           <>
+                            <Tooltip title="Editar informações">
+                              <Button
+                                size="small"
+                                color="inherit"
+                                startIcon={<EditIcon />}
+                                onClick={() => abrirEdicao(r)}
+                              >
+                                Editar
+                              </Button>
+                            </Tooltip>
                             <Tooltip title="Aprovar (envia e-mail)">
                               <Button
                                 size="small"
@@ -206,16 +253,28 @@ const ResponsaveisPage = () => {
                           </>
                         )}
                         {r.status === "Aprovado" && (
-                          <Tooltip title="Revogar acesso com motivo (envia e-mail)">
-                            <Button
-                              size="small"
-                              color="error"
-                              startIcon={<BlockIcon />}
-                              onClick={() => abrirAcao(r, "revogar")}
-                            >
-                              Revogar
-                            </Button>
-                          </Tooltip>
+                          <>
+                            <Tooltip title="Editar informações">
+                              <Button
+                                size="small"
+                                color="inherit"
+                                startIcon={<EditIcon />}
+                                onClick={() => abrirEdicao(r)}
+                              >
+                                Editar
+                              </Button>
+                            </Tooltip>
+                            <Tooltip title="Revogar acesso com motivo (envia e-mail)">
+                              <Button
+                                size="small"
+                                color="error"
+                                startIcon={<BlockIcon />}
+                                onClick={() => abrirAcao(r, "revogar")}
+                              >
+                                Revogar
+                              </Button>
+                            </Tooltip>
+                          </>
                         )}
                       </TableCell>
                     </TableRow>
@@ -286,6 +345,54 @@ const ResponsaveisPage = () => {
                 disabled={salvando}
               >
                 {salvando ? "Processando..." : tituloAcao[dialogAcao.acao]}
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+
+      <Dialog
+        open={!!dialogEdicao}
+        onClose={() => !salvandoEdicao && setDialogEdicao(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        {dialogEdicao && (
+          <>
+            <DialogTitle>Editar responsável</DialogTitle>
+            <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: "8px !important" }}>
+              {erroEdicao && <Alert severity="error">{erroEdicao}</Alert>}
+              <Typography variant="body2" color="text.secondary">
+                Editando: <strong>{dialogEdicao.usuarioNome}</strong> — <strong>{dialogEdicao.igrejaNome}</strong>
+              </Typography>
+              <TextField
+                label="Cargo Informado"
+                value={formEdicao.cargoInformado}
+                onChange={(e) => setFormEdicao({ ...formEdicao, cargoInformado: e.target.value })}
+                fullWidth
+                placeholder="ex: Pároco, Secretária, etc."
+              />
+              <TextField
+                label="Observação da Solicitação"
+                value={formEdicao.observacaoSolicitacao}
+                onChange={(e) => setFormEdicao({ ...formEdicao, observacaoSolicitacao: e.target.value })}
+                multiline
+                minRows={3}
+                fullWidth
+                placeholder="Observações adicionais..."
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setDialogEdicao(null)} disabled={salvandoEdicao}>
+                Cancelar
+              </Button>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={salvarEdicao}
+                disabled={salvandoEdicao}
+              >
+                {salvandoEdicao ? "Salvando..." : "Salvar"}
               </Button>
             </DialogActions>
           </>

--- a/src/utils/redeSocialUrl.js
+++ b/src/utils/redeSocialUrl.js
@@ -1,0 +1,20 @@
+export const construirUrlRedeSocial = (tipoRedeSocial, nomeDoPerfil) => {
+  if (!nomeDoPerfil || !nomeDoPerfil.trim()) return null;
+
+  const perfil = nomeDoPerfil.trim();
+
+  switch (Number(tipoRedeSocial)) {
+    case 1: // Facebook
+      return `https://www.facebook.com/${perfil}`;
+    case 2: // Instagram
+      return `https://www.instagram.com/${perfil}`;
+    case 3: // YouTube
+      return `https://www.youtube.com/${perfil}`;
+    case 4: // TikTok
+      return `https://www.tiktok.com/@${perfil}`;
+    case 5: // Twitter
+      return `https://www.twitter.com/${perfil}`;
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
## Summary
- Adicionar badges visuais "Responsável" na lista e editor de igrejas
- Adicionar links clicáveis nas redes sociais (Facebook, Instagram, YouTube, TikTok, Twitter)
- Implementar popup de edição na tela de Responsáveis Verificados

## Changes
- [x] Badge "Responsável" na lista de igrejas
- [x] Badge "Tem responsável" ao editar uma igreja
- [x] Links clicáveis nas redes sociais do editor
- [x] Botão "Editar" na tela de Responsáveis Verificados
- [x] Dialog de edição para cargo e observação

## Test plan
- [ ] Verificar badges na lista de igrejas quando houver responsável
- [ ] Verificar badges ao editar uma igreja com responsável
- [ ] Testar links das redes sociais
- [ ] Testar edição de responsável na tela de Responsáveis Verificados

🤖 Generated with [Claude Code](https://claude.com/claude-code)