### PR TITLE
Corrigir badge de responsável para usar temResponsavelAprovado

### DIFF
--- a/src/Igreja/Igreja.jsx
+++ b/src/Igreja/Igreja.jsx
@@ -468,7 +468,7 @@ const IgrejaPage = () => {
                       <TableCell>
                         <Stack direction="row" spacing={1} alignItems="center">
                           <Typography sx={{ fontWeight: 600 }}>{row.nome}</Typography>
-                          {row.usuarioId && (
+                          {row.temResponsavelAprovado && (
                             <Chip
                               label="Responsável"
                               size="small"

--- a/src/Igreja/IgrejaAtualizar.jsx
+++ b/src/Igreja/IgrejaAtualizar.jsx
@@ -784,7 +784,7 @@ const IgrejaAtualizar = () => {
                   }
                   label="Ativo"
               />
-              {state?.row?.usuarioId && (
+              {state?.row?.temResponsavelAprovado && (
                 <Chip
                     label="Tem responsável"
                     size="small"

--- a/src/Responsaveis.jsx
+++ b/src/Responsaveis.jsx
@@ -27,7 +27,9 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import BlockIcon from "@mui/icons-material/Block";
 import EditIcon from "@mui/icons-material/Edit";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import api from "./services/apiService";
+import { useNavigate } from "react-router-dom";
 
 const STATUS_META = {
   PendenteVerificacao: { label: "Pendente", color: "warning" },
@@ -38,6 +40,7 @@ const STATUS_META = {
 
 // Abas: 0 = fila de pendentes, 1 = histórico completo
 const ResponsaveisPage = () => {
+  const navigate = useNavigate();
   const [aba, setAba] = useState(0);
   const [registros, setRegistros] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -218,6 +221,16 @@ const ResponsaveisPage = () => {
                         <Chip size="small" label={meta.label} color={meta.color} />
                       </TableCell>
                       <TableCell align="center" sx={{ whiteSpace: "nowrap" }}>
+                        <Tooltip title="Ir para edição da Igreja">
+                          <Button
+                            size="small"
+                            color="primary"
+                            startIcon={<OpenInNewIcon />}
+                            onClick={() => navigate("/igrejas/editar", { state: { row: { id: r.igrejaId } } })}
+                          >
+                            Igreja
+                          </Button>
+                        </Tooltip>
                         {r.status === "PendenteVerificacao" && (
                           <>
                             <Tooltip title="Editar informações">


### PR DESCRIPTION
## Summary
Atualizar o frontend para usar o novo campo `temResponsavelAprovado` que verifica corretamente a tabela `IgrejaResponsavel`.

## Changes
- [x] Atualizar Igreja.jsx para usar temResponsavelAprovado
- [x] Atualizar IgrejaAtualizar.jsx para usar temResponsavelAprovado
- [x] Badge agora aparece apenas para igrejas com responsável verificado e aprovado

## Test plan
- [ ] Verificar badges na lista de igrejas quando houver responsável aprovado
- [ ] Verificar badges ao editar uma igreja com responsável aprovado
- [ ] Confirmar que igrejas sem responsável não mostram badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)