### PR TITLE
Soft delete de igreja no admin + dashboard de indicadores expandido

### DIFF
--- a/src/Components/DeleteConfirmModal.jsx
+++ b/src/Components/DeleteConfirmModal.jsx
@@ -31,7 +31,7 @@ const DeleteConfirmModal = ({ open, onClose, onConfirm, targetId }) => {
       <DialogTitle>Confirmar exclusão</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          Esta ação excluirá permanentemente o registro. Para confirmar, digite o ID da igreja abaixo e clique em "Confirmar".
+          A igreja será ocultada do site público, mas os dados são mantidos e a exclusão pode ser desfeita depois (botão &quot;Restaurar&quot;). Para confirmar, digite o ID da igreja abaixo e clique em &quot;Confirmar&quot;.
         </DialogContentText>
         <Box mt={2}>
           <TextField

--- a/src/Igreja/Igreja.jsx
+++ b/src/Igreja/Igreja.jsx
@@ -29,6 +29,7 @@ import HideSourceIcon from "@mui/icons-material/HideSource";
 import AnnouncementIcon from "@mui/icons-material/Announcement";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import DeleteIcon from '@mui/icons-material/Delete';
+import RestoreFromTrashIcon from '@mui/icons-material/RestoreFromTrash';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Link from '@mui/material/Link';
 import { useNavigate } from "react-router-dom";
@@ -206,6 +207,18 @@ const IgrejaPage = () => {
       });
   };
 
+  const handleRestaurar = (igrejaId) => {
+    api
+      .post(`/api/v1/Admin/igreja/restaurar/${igrejaId}`)
+      .then((response) => {
+        console.log(response.data?.data?.mensagemAplicacao || "Igreja restaurada");
+        fetchIgrejas(paginacao.pageIndex, paginacao.pageSize, searchFilters);
+      })
+      .catch((error) => {
+        console.error("Erro ao restaurar igreja:", error);
+      });
+  };
+
   const buildIgrejasEndpoint = (pageIndex, pageSize, filters) => {
     const params = new URLSearchParams();
     if (filters?.ativo !== undefined && filters.ativo !== "") {
@@ -221,6 +234,7 @@ const IgrejaPage = () => {
     if (filters?.reportarProblema !== undefined && filters.reportarProblema !== "") {
       params.append("reportarProblema", filters.reportarProblema);
     }
+    if (filters?.mostrarDeletadas) params.append("mostrarDeletadas", true);
     params.append("Paginacao.PageIndex", pageIndex);
     params.append("Paginacao.PageSize", pageSize);
     return `/api/v1/admin/igreja/buscar-por-filtro?${params.toString()}`;
@@ -299,11 +313,19 @@ const IgrejaPage = () => {
           </IconButton>
         </Tooltip>
       )}
-      <Tooltip title="Deletar">
-        <IconButton color="error" onClick={() => handleOpenDeleteModal(row.id)}>
-          <DeleteIcon />
-        </IconButton>
-      </Tooltip>
+      {row.deletadoEm ? (
+        <Tooltip title="Restaurar">
+          <IconButton color="success" onClick={() => handleRestaurar(row.id)}>
+            <RestoreFromTrashIcon />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip title="Deletar">
+          <IconButton color="error" onClick={() => handleOpenDeleteModal(row.id)}>
+            <DeleteIcon />
+          </IconButton>
+        </Tooltip>
+      )}
     </Stack>
   );
 
@@ -368,11 +390,16 @@ const IgrejaPage = () => {
                               {row.endereco?.localidade} / {row.endereco?.uf}
                             </Typography>
                           </Box>
-                          <Chip
-                            label={row.ativo ? "Ativo" : "Inativo"}
-                            size="small"
-                            color={row.ativo ? "success" : "default"}
-                          />
+                          <Stack direction="row" spacing={0.5}>
+                            {row.deletadoEm && (
+                              <Chip label="Excluída" size="small" color="error" />
+                            )}
+                            <Chip
+                              label={row.ativo ? "Ativo" : "Inativo"}
+                              size="small"
+                              color={row.ativo ? "success" : "default"}
+                            />
+                          </Stack>
                         </Stack>
                         {row.endereco?.cep && (
                           <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
@@ -475,6 +502,9 @@ const IgrejaPage = () => {
                               color="primary"
                               variant="outlined"
                             />
+                          )}
+                          {row.deletadoEm && (
+                            <Chip label="Excluída" size="small" color="error" />
                           )}
                         </Stack>
                       </TableCell>

--- a/src/Igreja/IgrejaSearchForm.jsx
+++ b/src/Igreja/IgrejaSearchForm.jsx
@@ -26,6 +26,7 @@ const FILTROS_PADRAO = {
   ativo: true,
   reportarProblema: false,
   semCoordenadas: false,
+  mostrarDeletadas: false,
 };
 
 const IgrejaSearchForm = ({
@@ -182,6 +183,7 @@ const IgrejaSearchForm = ({
     if (filtros.horario !== "") endPoint += `&horario=${filtros.horario}`;
     if (filtros.reportarProblema !== "") endPoint += `&reportarProblema=${filtros.reportarProblema}`;
     if (filtros.semCoordenadas) endPoint += `&semCoordenadas=true`;
+    if (filtros.mostrarDeletadas) endPoint += `&mostrarDeletadas=true`;
 
     let paginacao = `&Paginacao.PageIndex=1&Paginacao.PageSize=10`;
     endPoint += paginacao;
@@ -453,6 +455,15 @@ const IgrejaSearchForm = ({
                 />
               }
               label="Sem coordenadas"
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={formData.mostrarDeletadas}
+                  onChange={(e) => handleChange("mostrarDeletadas", e.target.checked)}
+                />
+              }
+              label="Mostrar excluídas"
             />
           </Box>
 

--- a/src/Indicadores/Indicadores.jsx
+++ b/src/Indicadores/Indicadores.jsx
@@ -26,6 +26,13 @@ import VisibilityIcon from "@mui/icons-material/Visibility";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import ShareIcon from "@mui/icons-material/Share";
 import HomeIcon from "@mui/icons-material/Home";
+import FunctionsIcon from "@mui/icons-material/Functions";
+import LocationCityIcon from "@mui/icons-material/LocationCity";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import ChecklistIcon from "@mui/icons-material/Checklist";
+import VerifiedUserIcon from "@mui/icons-material/VerifiedUser";
+import LoginIcon from "@mui/icons-material/Login";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
 import TrendingDownIcon from "@mui/icons-material/TrendingDown";
 import TrendingFlatIcon from "@mui/icons-material/TrendingFlat";
@@ -171,6 +178,37 @@ const StatCard = ({ titulo, valor, icon: Icon, color, tendencia }) => (
   </Card>
 );
 
+// Card compacto para os indicadores secundários (visualizações de página, favoritos, compartilhamentos).
+const MiniStatCard = ({ titulo, valor, icon: Icon, color }) => (
+  <Card variant="outlined" sx={{ p: 1.5, height: "100%" }}>
+    <Stack direction="row" spacing={1.5} alignItems="center">
+      <Box
+        sx={{
+          width: 34,
+          height: 34,
+          borderRadius: 1.5,
+          bgcolor: `${color}1a`,
+          color,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <Icon sx={{ fontSize: 18 }} />
+      </Box>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography variant="caption" color="text.secondary" fontWeight={500} noWrap>
+          {titulo}
+        </Typography>
+        <Typography variant="h6" fontWeight={700} sx={{ color }}>
+          {valor ?? 0}
+        </Typography>
+      </Box>
+    </Stack>
+  </Card>
+);
+
 // Etapa 5: cabeçalho, espaçamento e altura padronizados em todos os rankings.
 // Etapa 6: cidade/UF exibidos como subtítulo junto ao nome da igreja.
 const RankingTable = ({ titulo, descricao, itens, onIgrejaClick }) => {
@@ -305,9 +343,11 @@ const Indicadores = () => {
   const rankings = dados.rankings || {};
   const serieTemporal = dados.serieTemporal || [];
   const periodoAtivo = filtros.dataInicial || filtros.dataFinal;
+  const paginas = totais.paginas || {};
 
   // Etapa 10: empty state quando não há nenhum registro no período informado.
   const semDados =
+    !totais.totalGeral &&
     !totais.visualizacoes &&
     !totais.favoritos &&
     !totais.compartilhamentos &&
@@ -386,6 +426,43 @@ const Indicadores = () => {
           </Paper>
         ) : (
           <>
+            <Paper
+              sx={{
+                p: 2.5,
+                borderRadius: 2,
+                bgcolor: "#6366f11a",
+                border: "1px solid",
+                borderColor: "#6366f14d",
+              }}
+            >
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Box
+                  sx={{
+                    width: 56,
+                    height: 56,
+                    borderRadius: 2,
+                    bgcolor: "#6366f11a",
+                    color: "#6366f1",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexShrink: 0,
+                  }}
+                >
+                  <FunctionsIcon sx={{ fontSize: 30 }} />
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" fontWeight={500}>
+                    Total geral de indicadores clicados no site
+                  </Typography>
+                  <Typography variant="h3" fontWeight={700} sx={{ color: "#6366f1" }}>
+                    {totais.totalGeral ?? 0}
+                  </Typography>
+                  <TendenciaBadge tendencia={calcularTendencia(totais.totalGeral, totaisAnteriores?.totalGeral)} />
+                </Box>
+              </Stack>
+            </Paper>
+
             <Grid container spacing={2}>
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <StatCard
@@ -422,6 +499,33 @@ const Indicadores = () => {
                   color="#10b981"
                   tendencia={calcularTendencia(totais.visualizacoesHome, totaisAnteriores?.visualizacoesHome)}
                 />
+              </Grid>
+            </Grid>
+
+            <Grid container spacing={1.5}>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Cidades" valor={paginas.cidades} icon={LocationCityIcon} color="#0ea5e9" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Missa Agora" valor={paginas.missaAgora} icon={AccessTimeIcon} color="#f59e0b" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Como Funciona" valor={paginas.comoFunciona} icon={HelpOutlineIcon} color="#14b8a6" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Minhas Igrejas" valor={paginas.minhasIgrejas} icon={ChecklistIcon} color="#ec4899" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Guia Responsável" valor={paginas.guiaResponsavel} icon={VerifiedUserIcon} color="#8b5cf6" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Entrar" valor={paginas.entrar} icon={LoginIcon} color="#64748b" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Favoritos" valor={totais.favoritos} icon={FavoriteIcon} color="#ec4899" />
+              </Grid>
+              <Grid size={{ xs: 6, sm: 4, md: 1.5 }}>
+                <MiniStatCard titulo="Compartilhamentos" valor={totais.compartilhamentos} icon={ShareIcon} color="#8b5cf6" />
               </Grid>
             </Grid>
 


### PR DESCRIPTION
## Summary
- Tela de Igrejas ganha filtro "Mostrar excluídas", badge "Excluída" e botão de restaurar (substitui o de deletar quando aplicável)
- Modal de confirmação de exclusão atualizado para deixar claro que a ação é reversível
- Tela de Indicadores ganha card de Total Geral (destaque) e cards menores para as 6 novas páginas rastreadas + favoritos + compartilhamentos

## Test plan
- [ ] Excluir uma igreja e confirmar badge "Excluída" + botão restaurar
- [ ] Restaurar e confirmar volta ao estado normal
- [ ] Conferir filtro "Mostrar excluídas" na busca
- [ ] Conferir card de Total Geral e os 8 cards menores na tela de Indicadores