### PR TITLE
Tela admin de candidatas a reclassificação de TipoIgreja

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import MesclarMetricas from './Igreja/MesclarMetricas';
 import FeatureTogglesPage from './FeatureToggles';
 import DiocesesPage from './Dioceses';
 import SolicitacoesVinculoCapelaPage from './SolicitacoesVinculoCapela';
+import CandidatosTipoIgrejaPage from './CandidatosTipoIgreja';
 import ResponsaveisPage from './Responsaveis';
 import NotificacoesPage from './Notificacoes';
 import PrivateRoute from './PrivateRoute'
@@ -161,6 +162,14 @@ const App = () => {
                 element={
                     <PrivateRoute isAuthenticated={isAuthenticated} loading={loading}>
                         <SolicitacoesVinculoCapelaPage />
+                    </PrivateRoute>
+                }
+            />
+            <Route
+                path="/candidatos-tipo-igreja"
+                element={
+                    <PrivateRoute isAuthenticated={isAuthenticated} loading={loading}>
+                        <CandidatosTipoIgrejaPage />
                     </PrivateRoute>
                 }
             />

--- a/src/CandidatosTipoIgreja.jsx
+++ b/src/CandidatosTipoIgreja.jsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import Menu from "./Components/Menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  CircularProgress,
+  Box,
+  Typography,
+  Button,
+  Chip,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import api from "./services/apiService";
+import { useNavigate } from "react-router-dom";
+
+const CandidatosTipoIgrejaPage = () => {
+  const navigate = useNavigate();
+  const [registros, setRegistros] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [aplicandoId, setAplicandoId] = useState(null);
+  const [aplicados, setAplicados] = useState(new Set());
+
+  const carregar = () => {
+    setIsLoading(true);
+    api
+      .get("/api/v1/admin/igreja/candidatos-tipo-igreja")
+      .then((response) => setRegistros(response.data?.data || []))
+      .catch(() => setRegistros([]))
+      .finally(() => setIsLoading(false));
+  };
+
+  useEffect(() => {
+    carregar();
+  }, []);
+
+  const aplicar = (registro) => {
+    setAplicandoId(registro.id);
+    api
+      .put(`/api/v1/admin/igreja/${registro.id}/hierarquia`, {
+        tipoIgreja: registro.tipoIgrejaSugerido === "Capela" ? 2 : registro.tipoIgrejaSugerido === "Comunidade" ? 3 : 4,
+        igrejaPaiId: null,
+      })
+      .then(() => setAplicados((prev) => new Set(prev).add(registro.id)))
+      .catch(() => {})
+      .finally(() => setAplicandoId(null));
+  };
+
+  return (
+    <Menu>
+      <TableContainer component={Paper} sx={{ p: 2, borderRadius: 2, overflow: "auto" }}>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="h5" fontWeight={600}>
+            Candidatas a reclassificação de tipo
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Igrejas hoje classificadas como Paróquia (valor padrão do backfill original) cujo nome sugere
+            capela/comunidade/santuário. Identificação por heurística — revise antes de aplicar (ex.: &quot;Paróquia
+            Santuário de Fátima&quot; pode legitimamente ser uma paróquia). Aplicar só corrige o TIPO; a paróquia-sede
+            continua sendo definida à parte, na tela de edição da igreja.
+          </Typography>
+        </Box>
+
+        {isLoading ? (
+          <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" py={4}>
+            <CircularProgress size={60} />
+            <Typography variant="h6" mt={2}>
+              Carregando...
+            </Typography>
+          </Box>
+        ) : (
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Id</TableCell>
+                <TableCell>Nome</TableCell>
+                <TableCell>Cidade/UF</TableCell>
+                <TableCell>Tipo sugerido</TableCell>
+                <TableCell align="center">Ações</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {registros.length > 0 ? (
+                registros.map((r) => (
+                  <TableRow key={r.id}>
+                    <TableCell>{r.id}</TableCell>
+                    <TableCell>{r.nome}</TableCell>
+                    <TableCell>{[r.cidade, r.uf].filter(Boolean).join("/")}</TableCell>
+                    <TableCell>
+                      <Chip size="small" label={r.tipoIgrejaSugerido} />
+                    </TableCell>
+                    <TableCell align="center" sx={{ whiteSpace: "nowrap" }}>
+                      {aplicados.has(r.id) ? (
+                        <Chip size="small" label="Aplicado" color="success" />
+                      ) : (
+                        <>
+                          <Button
+                            size="small"
+                            color="success"
+                            startIcon={<CheckCircleIcon />}
+                            disabled={aplicandoId === r.id}
+                            onClick={() => aplicar(r)}
+                          >
+                            Aplicar
+                          </Button>
+                          <Button
+                            size="small"
+                            color="primary"
+                            startIcon={<OpenInNewIcon />}
+                            onClick={() => navigate("/igrejaEditar", { state: { row: { id: r.id } } })}
+                          >
+                            Ver
+                          </Button>
+                        </>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={5} align="center">
+                    <Typography color="text.secondary">Nenhuma candidata encontrada.</Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </TableContainer>
+    </Menu>
+  );
+};
+
+export default CandidatosTipoIgrejaPage;

--- a/src/Components/Menu.jsx
+++ b/src/Components/Menu.jsx
@@ -61,6 +61,7 @@ const navItems = [
       { path: "/aprovacoes", label: "Aprovações Pendentes", icon: FactCheckIcon, badgeKey: "aprovacoes" },
       { path: "/responsaveis", label: "Responsáveis Verificados", icon: VerifiedUserIcon, badgeKey: "responsaveis" },
       { path: "/solicitacoes-vinculo-capela", label: "Vínculos de Capela", icon: AccountBalanceIcon },
+      { path: "/candidatos-tipo-igreja", label: "Candidatas a Reclassificação", icon: AccountBalanceIcon },
       { path: "/reportar-problema", label: "Problemas Reportados", icon: AnnouncementIcon, badgeKey: "problemas" },
       { path: "/mesclar-metricas", label: "Mesclar Métricas", icon: MergeTypeIcon },
       { path: "/email-evento", label: "Divulgação", icon: EmailIcon },
@@ -98,6 +99,7 @@ const pageTitles = {
   "/notificacoes": "Notificações",
   "/responsaveis": "Responsáveis Verificados",
   "/solicitacoes-vinculo-capela": "Vínculos de Capela",
+  "/candidatos-tipo-igreja": "Candidatas a Reclassificação",
 };
 
 const Menu = ({ children }) => {


### PR DESCRIPTION
## Summary
- Depende do PR de mesma branch no `buscamissa-api-admin`.
- Nova página "Candidatas a Reclassificação" (`/candidatos-tipo-igreja`): lista o resultado do script de identificação, com "Aplicar" (corrige só o tipo) e "Ver" (abre a edição completa pra revisar antes).

## Test plan
- [ ] Acessar a página, ver a lista de candidatas
- [ ] "Aplicar" numa linha → chip vira "Aplicado", tipo da igreja é corrigido (conferir na tela de edição)
- [ ] "Ver" abre a edição da igreja correta