### PR TITLE
Release: dropdown de Tipo na criação de igreja (admin)

### DIFF
--- a/src/Igreja/Components/IgrejaHierarquiaTab.jsx
+++ b/src/Igreja/Components/IgrejaHierarquiaTab.jsx
@@ -15,15 +15,7 @@ import {
 } from "@mui/material";
 import api from "../../services/apiService";
 import ErrorSpan from "../../ErrorSpan";
-
-// Espelha Enums/TipoIgrejaEnum.cs do backend — o banco persiste o int cru.
-const TIPOS_IGREJA = [
-  { valor: 1, nome: "Paróquia" },
-  { valor: 2, nome: "Capela" },
-  { valor: 3, nome: "Comunidade" },
-  { valor: 4, nome: "Santuário" },
-  { valor: 99, nome: "Outro" },
-];
+import { TIPOS_IGREJA } from "../constants/tiposIgreja";
 
 const IgrejaHierarquiaTab = ({ igrejaId, uf }) => {
   const [loading, setLoading] = useState(true);

--- a/src/Igreja/IgrejaCriar.jsx
+++ b/src/Igreja/IgrejaCriar.jsx
@@ -10,6 +10,10 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
 } from "@mui/material";
 import { ArrowBack } from "@mui/icons-material";
 import api from "../services/apiService";
@@ -24,6 +28,7 @@ import EnderecoForm from "./Components/EnderecoForm";
 import SectionCard from "./Components/SectionCard";
 import RedesSociaisCriarSection from "./Components/RedesSociaisCriarSection";
 import IgrejasCepModal from "./Components/IgrejasCepModal";
+import { TIPOS_IGREJA } from "./constants/tiposIgreja";
 
 const IgrejaCriar = () => {
   const [message, setMessage] = useState("");
@@ -32,6 +37,7 @@ const IgrejaCriar = () => {
 
   const [formData, setFormData] = useState({
     nome: "",
+    tipoIgreja: 1,
     paroco: "",
     imagem: "",
     contato: {
@@ -98,6 +104,7 @@ const IgrejaCriar = () => {
   const limparFormulario = () => {
     setFormData({
       nome: "",
+      tipoIgreja: 1,
       paroco: "",
       imagem: "",
       contato: {
@@ -560,6 +567,22 @@ const IgrejaCriar = () => {
               subtitle="Informe os dados principais da igreja."
           >
             <Box display="flex" flexDirection="column" gap={2}>
+              <FormControl fullWidth required>
+                <InputLabel id="tipo-igreja-label">Tipo</InputLabel>
+                <Select
+                    labelId="tipo-igreja-label"
+                    label="Tipo"
+                    value={formData.tipoIgreja}
+                    onChange={(e) => handleChange("tipoIgreja", e.target.value)}
+                >
+                  {TIPOS_IGREJA.map((t) => (
+                      <MenuItem key={t.valor} value={t.valor}>
+                        {t.nome}
+                      </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
               <TextField
                   label="Nome da Igreja"
                   value={formData.nome}

--- a/src/Igreja/constants/tiposIgreja.js
+++ b/src/Igreja/constants/tiposIgreja.js
@@ -1,0 +1,8 @@
+// Espelha Enums/TipoIgrejaEnum.cs do backend — o banco persiste o int cru.
+export const TIPOS_IGREJA = [
+  { valor: 1, nome: "Paróquia" },
+  { valor: 2, nome: "Capela" },
+  { valor: 3, nome: "Comunidade" },
+  { valor: 4, nome: "Santuário" },
+  { valor: 99, nome: "Outro" },
+];


### PR DESCRIPTION
## Summary
Promove pra master o que já está validado em dev:
- Adicionado dropdown "Tipo" na tela de criação de igreja (IgrejaCriar.jsx), antes inexistente — toda igreja criada pelo admin caía no default do backend (Paroquia).
- Lista de tipos extraída para constante compartilhada, reaproveitada também na edição (IgrejaHierarquiaTab).

## Test plan
- [ ] Já testado manualmente pelo usuário
- [ ] Conferir deploy de produção após o merge